### PR TITLE
Hukoyun/theme

### DIFF
--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -750,4 +750,9 @@ MICROSITE_ROOT_DIR = path(ENV_TOKENS.get('MICROSITE_ROOT_DIR', ''))
 if ENV_TOKENS.get('AUDIT_CERT_CUTOFF_DATE', None):
     AUDIT_CERT_CUTOFF_DATE = dateutil.parser.parse(ENV_TOKENS.get('AUDIT_CERT_CUTOFF_DATE'))
 
+#To modify the country or region list use the override list in server-vars.yml
+_COUNTRIES_OVERRIDE = ENV_TOKENS.get('COUNTRIES_OVERRIDE')
+if _COUNTRIES_OVERRIDE:
+    COUNTRIES_OVERRIDE = _COUNTRIES_OVERRIDE
+
 

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -750,8 +750,8 @@ MICROSITE_ROOT_DIR = path(ENV_TOKENS.get('MICROSITE_ROOT_DIR', ''))
 if ENV_TOKENS.get('AUDIT_CERT_CUTOFF_DATE', None):
     AUDIT_CERT_CUTOFF_DATE = dateutil.parser.parse(ENV_TOKENS.get('AUDIT_CERT_CUTOFF_DATE'))
 
-#To modify the country or region list use the override list in server-vars.yml
-_COUNTRIES_OVERRIDE = ENV_TOKENS.get('COUNTRIES_OVERRIDE')
+# django-countries overrides
+_COUNTRIES_OVERRIDE = ENV_TOKENS.get('COUNTRIES_OVERRIDE', None)
 if _COUNTRIES_OVERRIDE:
     COUNTRIES_OVERRIDE = _COUNTRIES_OVERRIDE
 

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -750,9 +750,4 @@ MICROSITE_ROOT_DIR = path(ENV_TOKENS.get('MICROSITE_ROOT_DIR', ''))
 if ENV_TOKENS.get('AUDIT_CERT_CUTOFF_DATE', None):
     AUDIT_CERT_CUTOFF_DATE = dateutil.parser.parse(ENV_TOKENS.get('AUDIT_CERT_CUTOFF_DATE'))
 
-#To modify the country or region list use the override list in server-vars.yml
-_COUNTRIES_OVERRIDE = ENV_TOKENS.get('COUNTRIES_OVERRIDE')
-if _COUNTRIES_OVERRIDE:
-    COUNTRIES_OVERRIDE = _COUNTRIES_OVERRIDE
-
 

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -749,3 +749,10 @@ MICROSITE_ROOT_DIR = path(ENV_TOKENS.get('MICROSITE_ROOT_DIR', ''))
 # Cutoff date for granting audit certificates
 if ENV_TOKENS.get('AUDIT_CERT_CUTOFF_DATE', None):
     AUDIT_CERT_CUTOFF_DATE = dateutil.parser.parse(ENV_TOKENS.get('AUDIT_CERT_CUTOFF_DATE'))
+
+#To modify the country or region list use the override list in server-vars.yml
+_COUNTRIES_OVERRIDE = ENV_TOKENS.get('COUNTRIES_OVERRIDE')
+if _COUNTRIES_OVERRIDE:
+    COUNTRIES_OVERRIDE = _COUNTRIES_OVERRIDE
+
+


### PR DESCRIPTION
Added code to the end of aws.py so that COUNTRIES_OVERRIDE value can be fetched from environment. That way country list can be modified by defining the value in server-vars.yml with EDXAPP_COUNTRIES_OVERRIDE dictionary. 

A sample dictionary is like that. Setting null removes the country from list.
EDXAPP_COUNTRIES_OVERRIDE:
  XX: "New name for existing country"
  XY: null   
  XZ: "Add new country"

@Microsoft/lex 