### PR TITLE
wip: OAUTH2-backed APIs: Add RestrictedApplication scopes, permission checks, and filtering

### DIFF
--- a/common/djangoapps/enrollment/api.py
+++ b/common/djangoapps/enrollment/api.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 DEFAULT_DATA_API = 'enrollment.data'
 
 
-def get_enrollments(user_id):
+def get_enrollments(user_id, org_filter=None):
     """Retrieves all the courses a user is enrolled in.
 
     Takes a user and retrieves all relative enrollments. Includes information regarding how the user is enrolled
@@ -25,6 +25,7 @@ def get_enrollments(user_id):
 
     Args:
         user_id (str): The username of the user we want to retrieve course enrollment information for.
+        org_filter (str): Optional. Only return courses related to the specified ORG.
 
     Returns:
         A list of enrollment information for the given user.
@@ -89,7 +90,7 @@ def get_enrollments(user_id):
         ]
 
     """
-    return _data_api().get_course_enrollments(user_id)
+    return _data_api().get_course_enrollments(user_id, org_filter=org_filter)
 
 
 def get_enrollment(user_id, course_id):

--- a/common/djangoapps/enrollment/data.py
+++ b/common/djangoapps/enrollment/data.py
@@ -42,7 +42,7 @@ def get_course_enrollments(user_id, org_filter=None):
     ).order_by('created')
 
     # apply ORG filter, if specified
-    # NOTE, do not do a Falsy type check here because and empty list
+    # NOTE, do not do a Falsy type check here because an empty list
     # and None do not have the same semantic meaning. None means no filtering.
     # Empty list means 'filter everything out'
     if org_filter is not None:

--- a/common/djangoapps/enrollment/data.py
+++ b/common/djangoapps/enrollment/data.py
@@ -23,13 +23,14 @@ from student.models import (
 log = logging.getLogger(__name__)
 
 
-def get_course_enrollments(user_id):
+def get_course_enrollments(user_id, org_filter=None):
     """Retrieve a list representing all aggregated data for a user's course enrollments.
 
     Construct a representation of all course enrollment data for a specific user.
 
     Args:
         user_id (str): The name of the user to retrieve course enrollment information for.
+        org_filter (str): Optional. Only return courses related to the specified ORG.
 
     Returns:
         A serializable list of dictionaries of all aggregated enrollment data for a user.
@@ -39,6 +40,18 @@ def get_course_enrollments(user_id):
         user__username=user_id,
         is_active=True
     ).order_by('created')
+
+    # apply ORG filter, if specified
+    # NOTE, do not do a Falsy type check here because and empty list
+    # and None do not have the same semantic meaning. None means no filtering.
+    # Empty list means 'filter everything out'
+    if org_filter is not None:
+        _set = []
+        for enrollment in qset:
+            if enrollment.course_id.org in org_filter:
+                _set.append(enrollment)
+
+        qset = _set
 
     enrollments = CourseEnrollmentSerializer(qset, many=True).data
 

--- a/common/djangoapps/enrollment/tests/fake_data_api.py
+++ b/common/djangoapps/enrollment/tests/fake_data_api.py
@@ -25,7 +25,7 @@ _VERIFIED_MODE_EXPIRED = []
 
 
 # pylint: disable=unused-argument
-def get_course_enrollments(student_id):
+def get_course_enrollments(student_id, org_filter=None):
     """Stubbed out Enrollment data request."""
     return _ENROLLMENTS
 

--- a/common/djangoapps/enrollment/tests/test_views.py
+++ b/common/djangoapps/enrollment/tests/test_views.py
@@ -29,6 +29,8 @@ from util.testing import UrlResetMixin
 from enrollment import api
 from enrollment.errors import CourseEnrollmentError
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.oauth_dispatch.models import RestrictedApplication
+from openedx.core.djangoapps.oauth_dispatch.tests.test_views import _DispatchingViewTestCase
 from openedx.core.djangoapps.user_api.models import UserOrgTag
 from openedx.core.lib.django_test_client_utils import get_absolute_url
 from student.models import CourseEnrollment
@@ -1110,3 +1112,166 @@ class EnrollmentCrossDomainTest(ModuleStoreTestCase):
             HTTP_REFERER=self.REFERER,
             HTTP_X_CSRFTOKEN=csrf_cookie
         )
+
+
+class RestrictedOAuth2ApplicationTests(_DispatchingViewTestCase, ModuleStoreTestCase):
+    """
+    Test accessing the Enrollments list API endpoint via
+    OAuth2 RestrictedApplication clients. We derive this
+    test class from _DispatchingViewTestCase (openedx/core/djangoapps/oauth_dispatch)
+    because most of the initial setup is already contained there
+    """
+
+    def setUp(self):
+        super(RestrictedOAuth2ApplicationTests, self).setUp()
+        self.url = reverse('access_token')
+        self.enrollments_url = reverse('courseenrollments')
+        self.course = CourseFactory.create()
+        self.second_org_course = CourseFactory.create(
+            org='SecondOrg'
+        )
+        self.not_associated_course = CourseFactory.create(
+            org='NotAssociated'
+        )
+
+        # enroll user associated with OAuth2 Client Application
+        # in all courses
+        api.add_enrollment(self.restricted_dot_app.user, str(self.course.id))
+        api.add_enrollment(self.restricted_dot_app.user, str(self.second_org_course.id))
+        api.add_enrollment(self.restricted_dot_app.user, str(self.not_associated_course.id))
+
+    def _post_body(self, user, client, token_type=None, scopes=None):
+        """
+        Return a dictionary to be used as the body of the POST request
+        """
+        body = {
+            'client_id': client.client_id,
+            'grant_type': 'password',
+            'username': user.username,
+            'password': 'test',
+        }
+
+        if token_type:
+            body['token_type'] = token_type
+
+        if scopes:
+            body['scope'] = scopes
+
+        return body
+
+    def _do_enrollments_call(self, dot_application, scopes):
+        """
+        Helper method to consolidate code
+        """
+
+        response = self._post_request(
+            self.user,
+            dot_application,
+            scopes=scopes,
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+
+        self.assertIn('access_token', data)
+
+        # call into Enrollments API endpoint
+        response = self.client.get(
+            self.enrollments_url,
+            HTTP_AUTHORIZATION="Bearer {0}".format(data['access_token'])
+        )
+        return response
+
+    def test_no_permissions(self):
+        """
+        assert that a RestrictedApplication client which DOES NOT have the
+        enrollments:read scope CANNOT access the Enrollments API
+        """
+
+        # call into Enrollments API endpoint with a 'profile' scoped access_token
+        response = self._do_enrollments_call(
+            self.restricted_dot_app_limited_scopes,
+            'profile'
+        )
+
+        # this should NOT have permission to access this API
+        self.assertEqual(response.status_code, 403)
+
+    def test_with_permissions(self):
+        """
+        assert that a RestrictedApplication client which DOES have the
+        enrollments:read scope CAN access the Enrollments API
+        """
+
+        # call into Enrollments API endpoint with a 'enrollments:read' scoped access_token
+        response = self._do_enrollments_call(
+            self.restricted_dot_app,
+            'enrollments:read'
+        )
+
+        # this should have permission to access this API endpoint
+        self.assertEqual(response.status_code, 200)
+
+    def test_no_org_associations(self):
+        """
+        Asserts that a RestrictedApplication with proper permissions
+        but no ORG associations, gets back an empty set
+        """
+
+        response = self._do_enrollments_call(
+            self.restricted_dot_app,
+            'enrollments:read'
+        )
+        data = json.loads(response.content)
+
+        # this should have permission to access this API endpoint
+        self.assertEqual(response.status_code, 200)
+        # but no data should be returned because this RestrictedApplication
+        # does not have any approved ORG associations
+        self.assertEqual(len(data), 0)
+
+    def test_single_org_association(self):
+        """
+        assert that org associations on a RestrictedApplication causes
+        proper filtering on the list of enrollments, aka on RestrictedApplicaton
+        cannot get data associated with a course ORG that is outside of
+        it's declared association
+        """
+
+        restricted_application = RestrictedApplication.objects.get(application=self.restricted_dot_app)
+        restricted_application.org_associations = [self.course.id.org]
+        restricted_application.save()
+
+        # call into Enrollments API endpoint with a 'enrollments:read' scoped access_token
+        response = self._do_enrollments_call(
+            self.restricted_dot_app,
+            'enrollments:read'
+        )
+        data = json.loads(response.content)
+
+        # this should have permission to access this API endpoint
+        self.assertEqual(response.status_code, 200)
+        # we should just get back a single enrollment
+        self.assertEqual(len(data), 1)
+
+    def test_multi_org_association(self):
+        """
+        assert that org associations on a RestrictedApplication causes
+        proper filtering on the list of enrollments, but we have
+        two ORGs associated with a RestrictedApplication
+        """
+
+        restricted_application = RestrictedApplication.objects.get(application=self.restricted_dot_app)
+        restricted_application.org_associations = [self.course.id.org, self.second_org_course.id.org]
+        restricted_application.save()
+
+        # call into Enrollments API endpoint with a 'enrollments:read' scoped access_token
+        response = self._do_enrollments_call(
+            self.restricted_dot_app,
+            'enrollments:read'
+        )
+        data = json.loads(response.content)
+
+        # this should have permission to access this API endpoint
+        self.assertEqual(response.status_code, 200)
+        # we should just get back a single enrollment
+        self.assertEqual(len(data), 2)

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -494,11 +494,9 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
             # For more information on RestrictedApplications and the
             # permissions model, see openedx/core/lib/api/permissions.py
 
-            print 'here'
             if hasattr(request, 'auth') and hasattr(request.auth, 'org_filter'):
               org_filter = request.auth.org_filter
 
-            print 'org_filter = {}'.format(org_filter)
             enrollment_data = api.get_enrollments(username, org_filter=org_filter)
         except CourseEnrollmentError:
             return Response(

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -494,8 +494,8 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
             # For more information on RestrictedApplications and the
             # permissions model, see openedx/core/lib/api/permissions.py
 
-            if hasattr(request, 'auth') and hasattr(request.auth, 'org_filter'):
-              org_filter = request.auth.org_filter
+            if hasattr(request, 'auth') and hasattr(request.auth, 'org_associations'):
+              org_filter = request.auth.org_associations
 
             enrollment_data = api.get_enrollments(username, org_filter=org_filter)
         except CourseEnrollmentError:

--- a/common/djangoapps/enrollment/views.py
+++ b/common/djangoapps/enrollment/views.py
@@ -11,7 +11,11 @@ from opaque_keys import InvalidKeyError
 from course_modes.models import CourseMode
 from openedx.core.lib.log_utils import audit_log
 from openedx.core.djangoapps.user_api.preferences.api import update_email_opt_in
-from openedx.core.lib.api.permissions import ApiKeyHeaderPermission, ApiKeyHeaderPermissionIsAuthenticated
+from openedx.core.lib.api.permissions import (
+  ApiKeyHeaderPermission,
+  ApiKeyHeaderPermissionIsAuthenticated,
+  OAuth2RestrictedApplicatonPermission
+)
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.throttling import UserRateThrottle
@@ -139,7 +143,7 @@ class EnrollmentView(APIView, ApiKeyPermissionMixIn):
    """
 
     authentication_classes = OAuth2AuthenticationAllowInactiveUser, SessionAuthenticationAllowInactiveUser
-    permission_classes = ApiKeyHeaderPermissionIsAuthenticated,
+    permission_classes = (ApiKeyHeaderPermissionIsAuthenticated, OAuth2RestrictedApplicatonPermission, )
     throttle_classes = EnrollmentUserThrottle,
 
     # Since the course about page on the marketing site uses this API to auto-enroll users,
@@ -449,7 +453,7 @@ class EnrollmentListView(APIView, ApiKeyPermissionMixIn):
              * user: The username of the user.
     """
     authentication_classes = OAuth2AuthenticationAllowInactiveUser, EnrollmentCrossDomainSessionAuth
-    permission_classes = ApiKeyHeaderPermissionIsAuthenticated,
+    permission_classes = (ApiKeyHeaderPermissionIsAuthenticated, OAuth2RestrictedApplicatonPermission, )
     throttle_classes = EnrollmentUserThrottle,
 
     # Since the course about page on the marketing site

--- a/common/djangoapps/third_party_auth/api/views.py
+++ b/common/djangoapps/third_party_auth/api/views.py
@@ -13,6 +13,7 @@ from openedx.core.lib.api.authentication import (
 )
 from openedx.core.lib.api.permissions import (
     ApiKeyHeaderPermission,
+    OAuth2RestrictedApplicatonPermission
 )
 from rest_framework import status, exceptions
 from rest_framework.response import Response
@@ -54,6 +55,7 @@ class UserView(APIView):
         OAuth2AuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser,
     )
+    permission_classes = (OAuth2RestrictedApplicatonPermission, )
 
     def get(self, request, username):
         """Create, read, or update enrollment information for a user.
@@ -173,6 +175,8 @@ class UserMappingView(ListAPIView):
     authentication_classes = (
         OAuth2Authentication,
     )
+
+    permission_classes = (OAuth2RestrictedApplicatonPermission, )
 
     serializer_class = serializers.UserMappingSerializer
     provider = None

--- a/lms/djangoapps/badges/api/views.py
+++ b/lms/djangoapps/badges/api/views.py
@@ -7,11 +7,12 @@ from rest_framework import generics
 from rest_framework.exceptions import APIException
 
 from openedx.core.djangoapps.user_api.permissions import is_field_shared_factory
+from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
 from openedx.core.lib.api.authentication import (
     OAuth2AuthenticationAllowInactiveUser,
     SessionAuthenticationAllowInactiveUser
 )
-from openedx.core.djangoapps.xmodule_django.models import CourseKeyField
+from openedx.core.lib.api.permissions import OAuth2RestrictedApplicatonPermission
 
 from badges.models import BadgeAssertion
 from .serializers import BadgeAssertionSerializer
@@ -97,7 +98,10 @@ class UserBadgeAssertions(generics.ListAPIView):
         OAuth2AuthenticationAllowInactiveUser,
         SessionAuthenticationAllowInactiveUser
     )
-    permission_classes = (is_field_shared_factory("accomplishments_shared"),)
+    permission_classes = (
+        is_field_shared_factory("accomplishments_shared"),
+        OAuth2RestrictedApplicatonPermission
+    )
 
     def filter_queryset(self, queryset):
         """

--- a/lms/djangoapps/certificates/apis/v0/views.py
+++ b/lms/djangoapps/certificates/apis/v0/views.py
@@ -72,7 +72,8 @@ class CertificatesDetailView(GenericAPIView):
     )
     permission_classes = (
         IsAuthenticated,
-        permissions.IsUserInUrlOrStaff
+        permissions.IsUserInUrlOrStaff,
+        permissions.OAuth2RestrictedApplicatonPermission,
     )
 
     def get(self, request, username, course_id):

--- a/lms/djangoapps/certificates/apis/v0/views.py
+++ b/lms/djangoapps/certificates/apis/v0/views.py
@@ -110,8 +110,8 @@ class CertificatesDetailView(GenericAPIView):
         #
         # For more information on RestrictedApplications and the
         # permissions model, see openedx/core/lib/api/permissions.py
-        if hasattr(request, 'auth') and hasattr(request.auth, 'org_filter'):
-            if course_key.org not in request.auth.org_filter:
+        if hasattr(request, 'auth') and hasattr(request.auth, 'org_associations'):
+            if course_key.org not in request.auth.org_associations:
                 return Response(
                     status=403,
                     data={'error_code': 'course_org_not_associated_with_calling_application'}

--- a/lms/djangoapps/commerce/api/v0/views.py
+++ b/lms/djangoapps/commerce/api/v0/views.py
@@ -21,6 +21,7 @@ from enrollment.views import EnrollmentCrossDomainSessionAuth
 from openedx.core.djangoapps.commerce.utils import ecommerce_api_client
 from openedx.core.djangoapps.user_api.preferences.api import update_email_opt_in
 from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.permissions import OAuth2RestrictedApplicatonPermission
 from openedx.core.lib.log_utils import audit_log
 from student.models import CourseEnrollment
 from util.json_request import JsonResponse
@@ -35,7 +36,7 @@ class BasketsView(APIView):
 
     # LMS utilizes User.user_is_active to indicate email verification, not whether an account is active. Sigh!
     authentication_classes = (EnrollmentCrossDomainSessionAuth, OAuth2AuthenticationAllowInactiveUser)
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, OAuth2RestrictedApplicatonPermission,)
 
     def _is_data_valid(self, request):
         """

--- a/lms/djangoapps/grades/api/tests/test_views.py
+++ b/lms/djangoapps/grades/api/tests/test_views.py
@@ -3,6 +3,8 @@ Tests for the views
 """
 from datetime import datetime
 import ddt
+import json
+
 from django.core.urlresolvers import reverse
 from mock import patch
 from opaque_keys import InvalidKeyError
@@ -14,11 +16,16 @@ from capa.tests.response_xml_factory import MultipleChoiceResponseXMLFactory
 from edx_oauth2_provider.tests.factories import AccessTokenFactory, ClientFactory
 from lms.djangoapps.courseware.tests.factories import GlobalStaffFactory, StaffFactory
 from lms.djangoapps.grades.tests.utils import mock_get_score
+from openedx.core.djangoapps.oauth_dispatch.models import RestrictedApplication
+from openedx.core.djangoapps.oauth_dispatch.tests.test_views import _DispatchingViewTestCase
 from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
-from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase, TEST_DATA_SPLIT_MODULESTORE
-
+from xmodule.modulestore.tests.django_utils import (
+    ModuleStoreTestCase,
+    SharedModuleStoreTestCase,
+    TEST_DATA_SPLIT_MODULESTORE
+)
 
 @ddt.ddt
 class CurrentGradeViewTest(SharedModuleStoreTestCase, APITestCase):
@@ -338,7 +345,10 @@ class GradingPolicyTestMixin(object):
         Returns Bearer auth header with a generated access token
         for the given user.
         """
-        access_token = AccessTokenFactory.create(user=user, client=self.oauth_client).token
+        access_token = AccessTokenFactory.create(
+            user=user,
+            client=self.oauth_client
+        ).token
         return 'Bearer ' + access_token
 
     def test_get_invalid_course(self):
@@ -492,3 +502,144 @@ class CourseGradingPolicyMissingFieldsTests(GradingPolicyTestMixin, SharedModule
             }
         ]
         self.assertListEqual(response.data, expected)
+
+
+class OAuth2RestrictedAppTests(_DispatchingViewTestCase, ModuleStoreTestCase):
+    """
+    Tests specifically around RestrictedApplications for OAuth2 clients
+    We separated this out from other OAuth tests above, because those
+    tests use the deprecated DOP framework (as opposed to DOT)
+    """
+
+    def setUp(self):
+        super(OAuth2RestrictedAppTests, self).setUp()
+        self.url = reverse('access_token')
+        self.course = CourseFactory.create()
+        self.second_org_course = CourseFactory.create(
+            org='SecondOrg'
+        )
+        self.not_associated_course = CourseFactory.create(
+            org='NotAssociated'
+        )
+
+        # enroll user associated with OAuth2 Client Application
+        # in all courses
+        CourseEnrollmentFactory(
+            course_id=self.course.id,
+            user=self.restricted_dot_app.user
+        )
+        CourseEnrollmentFactory(
+            course_id=self.second_org_course.id,
+            user=self.restricted_dot_app.user
+        )
+        CourseEnrollmentFactory(
+            course_id=self.not_associated_course.id,
+            user=self.restricted_dot_app.user
+        )
+
+    def _post_body(self, user, client, token_type=None, scopes=None):
+        """
+        Return a dictionary to be used as the body of the POST request
+        """
+        body = {
+            'client_id': client.client_id,
+            'grant_type': 'password',
+            'username': user.username,
+            'password': 'test',
+        }
+
+        if token_type:
+            body['token_type'] = token_type
+
+        if scopes:
+            body['scope'] = scopes
+
+        return body
+
+    def _do_grades_call(self, dot_application, scopes, course_key=None):
+        """
+        Helper method to consolidate code
+        """
+
+        response = self._post_request(
+            self.user,
+            dot_application,
+            scopes=scopes,
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+
+        self.assertIn('access_token', data)
+
+        # call into Enrollments API endpoint
+        url = "{0}?username={1}".format(
+            reverse(
+                'grades_api:user_grade_detail',
+                kwargs={
+                    'course_id': course_key if course_key else self.course.id,
+                }
+            ),
+            self.user.username
+        )
+        response = self.client.get(
+            url,
+            HTTP_AUTHORIZATION="Bearer {0}".format(data['access_token'])
+        )
+        return response
+
+    def test_wrong_scope(self):
+        """
+        assert that a RestrictedApplication client which DOES NOT have the
+        grades:read scope CANNOT access the Grade API
+        """
+
+        # call into Enrollments API endpoint with a 'profile' scoped access_token
+        response = self._do_grades_call(
+            self.restricted_dot_app_limited_scopes,
+            'profile'
+        )
+
+        # this should NOT have permission to access this API
+        self.assertEqual(response.status_code, 403)
+
+    def test_correct_scope_with_correct_org(self):
+        """
+        assert that a RestrictedApplication client which DOES have the
+        grade:read scope as well as being associated with the org CAN access the Grade API
+        """
+
+        restricted_application = RestrictedApplication.objects.get(application=self.restricted_dot_app)
+        restricted_application.org_associations = [self.course.id.org]
+        restricted_application.save()
+
+        # call into Enrollments API endpoint with a 'enrollments:read' scoped access_token
+        response = self._do_grades_call(
+            self.restricted_dot_app,
+            'grades:read'
+        )
+
+        # this should have permission to access this API endpoint
+        self.assertEqual(response.status_code, 200)
+
+    def test_correct_scope_with_wrong_org(self):
+        """
+        assert that a RestrictedApplication client which
+             - DOES have the grade:read scope as well
+             - IS NOT associated with requested org
+        CANNOT access the Grade API
+        """
+
+        restricted_application = RestrictedApplication.objects.get(application=self.restricted_dot_app)
+        restricted_application.org_associations = ['badorg']
+        restricted_application.save()
+
+        # call into Enrollments API endpoint with a 'enrollments:read' scoped access_token
+        response = self._do_grades_call(
+            self.restricted_dot_app,
+            'grades:read'
+        )
+
+        # this should have permission to access this API endpoint
+        self.assertEqual(response.status_code, 403)
+        data = json.loads(response.content)
+        self.assertEqual(data['error_code'], 'course_org_not_associated_with_calling_application')

--- a/lms/djangoapps/grades/api/views.py
+++ b/lms/djangoapps/grades/api/views.py
@@ -16,6 +16,7 @@ from lms.djangoapps.courseware import courses
 from lms.djangoapps.grades.api.serializers import GradingPolicySerializer
 from lms.djangoapps.grades.new.course_grade import CourseGradeFactory
 from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.permissions import OAuth2RestrictedApplicatonPermission
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 
 log = logging.getLogger(__name__)
@@ -29,7 +30,7 @@ class GradeViewMixin(DeveloperErrorViewMixin):
         OAuth2AuthenticationAllowInactiveUser,
         SessionAuthentication,
     )
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, OAuth2RestrictedApplicatonPermission,)
 
     def _get_course(self, course_key_string, user, access_action):
         """

--- a/lms/djangoapps/grades/api/views.py
+++ b/lms/djangoapps/grades/api/views.py
@@ -156,9 +156,9 @@ class UserGradeView(GradeViewMixin, GenericAPIView):
         #
         # For more information on RestrictedApplications and the
         # permissions model, see openedx/core/lib/api/permissions.py
-        if hasattr(request, 'auth') and hasattr(request.auth, 'org_filter'):
+        if hasattr(request, 'auth') and hasattr(request.auth, 'org_associations'):
             course_key = CourseKey.from_string(course_id)
-            if course_key.org not in request.auth.org_filter:
+            if course_key.org not in request.auth.org_associations:
                 return self.make_error_response(
                     status_code=status.HTTP_403_FORBIDDEN,
                     developer_message='The OAuth2 RestrictedApplication is not associated with org.',

--- a/lms/djangoapps/mobile_api/users/views.py
+++ b/lms/djangoapps/mobile_api/users/views.py
@@ -66,6 +66,12 @@ class UserDetail(generics.RetrieveAPIView):
     serializer_class = UserSerializer
     lookup_field = 'username'
 
+    # needed for passing OAuth2RestrictedApplicatonPermission checks
+    # for RestrictedApplications (only). A RestriectedApplication can
+    # only call this method if it is allowed to receive a 'profile'
+    # scope
+    required_scopes = ['profile']
+
 
 @mobile_view(is_user=True)
 class UserCourseStatus(views.APIView):

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -454,6 +454,10 @@ OAUTH2_PROVIDER = {
         # conform profile scope message that is presented to end-user
         # to lms/templates/provider/authorize.html. This may be revised later.
         'profile': 'Read your user profile',
+        # scopes to call into various APIs as read-only
+        'enrollments:read': 'Retrieve a list of your course enrollments',
+        'grades:read': 'Retrieve your grades for your enrolled courses',
+        'certificates:read': 'Retrieve your course certificates'
     },
 }
 # This is required for the migrations in oauth_dispatch.models

--- a/openedx/core/djangoapps/auth_exchange/views.py
+++ b/openedx/core/djangoapps/auth_exchange/views.py
@@ -29,6 +29,7 @@ import social.apps.django_app.utils as social_utils
 from openedx.core.djangoapps.auth_exchange.forms import AccessTokenExchangeForm
 from openedx.core.djangoapps.oauth_dispatch import adapters
 from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
+from openedx.core.lib.api.permissions import OAuth2RestrictedApplicatonPermission
 
 
 class AccessTokenExchangeBase(APIView):
@@ -149,7 +150,7 @@ class LoginWithAccessTokenView(APIView):
     View for exchanging an access token for session cookies
     """
     authentication_classes = (OAuth2AuthenticationAllowInactiveUser,)
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (permissions.IsAuthenticated, OAuth2RestrictedApplicatonPermission)
 
     @staticmethod
     def _get_path_of_arbitrary_backend_for_user(user):

--- a/openedx/core/djangoapps/oauth_dispatch/dot_overrides.py
+++ b/openedx/core/djangoapps/oauth_dispatch/dot_overrides.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 from .models import RestrictedApplication
 
 from datetime import datetime
+from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
@@ -24,9 +25,10 @@ def on_access_token_presave(sender, instance, *args, **kwargs):  # pylint: disab
     We do this as a pre-save hook on the ORM
     """
 
-    is_application_restricted = RestrictedApplication.is_token_a_restricted_application(instance)
-    if is_application_restricted:
-        RestrictedApplication.set_access_token_as_expired(instance)
+    if settings.FEATURES.get('AUTO_EXPIRE_RESTRICTED_ACCESS_TOKENS', False):
+        is_application_restricted = RestrictedApplication.is_token_a_restricted_application(instance)
+        if is_application_restricted:
+            RestrictedApplication.set_access_token_as_expired(instance)
 
 
 class EdxOAuth2Validator(OAuth2Validator):
@@ -84,7 +86,7 @@ class EdxOAuth2Validator(OAuth2Validator):
         super(EdxOAuth2Validator, self).save_bearer_token(token, request, *args, **kwargs)
 
         is_application_restricted = RestrictedApplication.objects.filter(application=request.client).exists()
-        if is_application_restricted:
+        if is_application_restricted and settings.FEATURES.get('AUTO_EXPIRE_RESTRICTED_ACCESS_TOKENS', False):
             # Since RestrictedApplications will override the DOT defined expiry, so that access_tokens
             # are always expired, we need to re-read the token from the database and then calculate the
             # expires_in (in seconds) from what we stored in the database. This value should be a negative

--- a/openedx/core/djangoapps/oauth_dispatch/dot_overrides.py
+++ b/openedx/core/djangoapps/oauth_dispatch/dot_overrides.py
@@ -24,7 +24,7 @@ def on_access_token_presave(sender, instance, *args, **kwargs):  # pylint: disab
     We do this as a pre-save hook on the ORM
     """
 
-    is_application_restricted = RestrictedApplication.objects.filter(application=instance.application).exists()
+    is_application_restricted = RestrictedApplication.is_token_a_restricted_application(instance)
     if is_application_restricted:
         RestrictedApplication.set_access_token_as_expired(instance)
 
@@ -103,3 +103,20 @@ class EdxOAuth2Validator(OAuth2Validator):
         # Restore the original request attributes
         request.grant_type = grant_type
         request.user = user
+
+    def validate_scopes(self, client_id, scopes, client, request, *args, **kwargs):
+        """
+        Override the DOT implementation to add checks to make sure that a
+        RestrictedApplication is not granted scopes that it has not been
+        permitted to do
+        """
+
+        restricted_application = RestrictedApplication.get_restricted_application(client)
+        if restricted_application:
+            # caller is restricted, so we must vet the allowed scopes for that restricted application
+            return set(scopes).issubset(restricted_application.allowed_scopes)
+
+        # not a restricted application, call into base implementation,
+        # which - basically - pulls the list of scopes from configuration settings as a global
+        # definition
+        return super(EdxOAuth2Validator, self).validate_scopes(client_id, scopes, client, request, *args, **kwargs)

--- a/openedx/core/djangoapps/oauth_dispatch/migrations/0002_auto_20161016_0926.py
+++ b/openedx/core/djangoapps/oauth_dispatch/migrations/0002_auto_20161016_0926.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('oauth_dispatch', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='restrictedapplication',
+            name='_allowed_scopes',
+            field=models.TextField(null=True),
+        ),
+        migrations.AddField(
+            model_name='restrictedapplication',
+            name='_org_associations',
+            field=models.TextField(null=True),
+        ),
+        migrations.AlterField(
+            model_name='restrictedapplication',
+            name='application',
+            field=models.ForeignKey(related_name='restricted_application', to=settings.OAUTH2_PROVIDER_APPLICATION_MODEL),
+        ),
+    ]

--- a/openedx/core/djangoapps/oauth_dispatch/models.py
+++ b/openedx/core/djangoapps/oauth_dispatch/models.py
@@ -7,6 +7,11 @@ from django.db import models
 from pytz import utc
 
 from oauth2_provider.settings import oauth2_settings
+from oauth2_provider.models import AccessToken
+
+# define default separator used to store lists
+# IMPORTANT: Do not change this after data has been populated in database
+_DEFAULT_SEPARATOR = ' '
 
 
 class RestrictedApplication(models.Model):
@@ -20,6 +25,15 @@ class RestrictedApplication(models.Model):
 
     application = models.ForeignKey(oauth2_settings.APPLICATION_MODEL, null=False)
 
+    # a space separated list of scopes that this application can request
+    _allowed_scopes = models.TextField(null=True)
+
+    # a space separated list of ORGs that this application is associated with
+    # this field will be used to implement appropriate data filtering
+    # so that clients of a specific OAuth2 Application will only be
+    # able retrieve datasets that the OAuth2 Application is allowed to retrieve.
+    _org_associations = models.TextField(null=True)
+
     def __unicode__(self):
         """
         Return a unicode representation of this object
@@ -27,6 +41,79 @@ class RestrictedApplication(models.Model):
         return u"<RestrictedApplication '{name}'>".format(
             name=self.application.name
         )
+
+    @classmethod
+    def is_token_a_restricted_application(cls, token):
+        """
+        Returns if token is issued to a RestriectedApplication
+        """
+
+        if isinstance(token, basestring):
+            # if string is passed in, do the look up
+            tokens = AccessToken.objects.all()
+            for token in tokens:
+                print token
+            token_obj = AccessToken.objects.get(token=token)
+        else:
+            token_obj = token
+
+        return cls.get_restricted_application(token_obj.application) is not None
+
+    @classmethod
+    def get_restricted_application(cls, application):
+        """
+        For a given application, get the related restricted application
+        """
+        return RestrictedApplication.objects.filter(application=application.id).first()
+
+    def _get_list_from_delimited_string(self, delimited_string, separator=_DEFAULT_SEPARATOR):
+        """
+        Helper to return a list from a delimited string
+        """
+
+        return delimited_string.split(separator) if delimited_string else []
+
+    @property
+    def allowed_scopes(self):
+        """
+        Translate space delimited string to a list
+        """
+        return self._get_list_from_delimited_string(self._allowed_scopes)
+
+    @allowed_scopes.setter
+    def allowed_scopes(self, value):
+        """
+        Convert list to separated string
+        """
+        self._allowed_scopes = _DEFAULT_SEPARATOR.join(value)
+
+    def has_scope(self, scope):
+        """
+        Returns in the RestrictedApplication has the requested scope
+        """
+
+        return scope in self.allowed_scopes
+
+    @property
+    def org_associations(self):
+        """
+        Translate space delimited string to a list
+        """
+        return self._get_list_from_delimited_string(self._org_associations)
+
+    @org_associations.setter
+    def org_associations(self, value):
+        """
+        Convert list to separated string
+        """
+        self._org_associations = _DEFAULT_SEPARATOR.join(value)
+
+    def is_associated_with_org(self, org):
+        """
+        Returns if the RestriectedApplication is associated with the requested org
+        """
+
+        return org in self.org_associations
 
     @classmethod
     def set_access_token_as_expired(cls, access_token):

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
@@ -90,10 +90,14 @@ class _DispatchingViewTestCase(TestCase):
 
         # Create a "restricted" DOT Application which means any AccessToken/JWT
         # generated for this application will be immediately expired
+        all_scopes = u' '.join([
+            scope for scope in settings.OAUTH2_PROVIDER['SCOPES'].keys()
+        ])
+
         self.restricted_dot_app = self._create_restricted_app(
             name='test restricted dot application',
             client_id='dot-restricted-app-client-id',
-            allowed_scopes = u'read write profile email',
+            allowed_scopes = all_scopes,
         )
 
         self.restricted_dot_app_limited_scopes = self._create_restricted_app(

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_views.py
@@ -90,22 +90,48 @@ class _DispatchingViewTestCase(TestCase):
 
         # Create a "restricted" DOT Application which means any AccessToken/JWT
         # generated for this application will be immediately expired
-        self.restricted_dot_app = self.dot_adapter.create_public_client(
+        self.restricted_dot_app = self._create_restricted_app(
             name='test restricted dot application',
+            client_id='dot-restricted-app-client-id',
+            allowed_scopes = u'read write profile email',
+        )
+
+        self.restricted_dot_app_limited_scopes = self._create_restricted_app(
+            name='test restricted dot application limited scopes',
+            client_id='dot-restricted-app-limited-scopes-client-id',
+            allowed_scopes = u'profile',
+        )
+
+
+    def _create_restricted_app(self, name, client_id, allowed_scopes):
+        """
+        Helper method to create a RestrictedApp
+        """
+
+        restricted_dot_app = self.dot_adapter.create_public_client(
+            name=name,
             user=self.user,
             redirect_uri=DUMMY_REDIRECT_URL,
-            client_id='dot-restricted-app-client-id',
+            client_id=client_id,
         )
-        models.RestrictedApplication.objects.create(application=self.restricted_dot_app)
+        restricted_app = models.RestrictedApplication.objects.create(
+            application=restricted_dot_app,
+            _allowed_scopes = allowed_scopes
+        )
 
-    def _post_request(self, user, client, token_type=None):
+        return restricted_dot_app
+
+    def _post_request(self, user, client, token_type=None, scopes=None):
         """
         Call the view with a POST request objectwith the appropriate format,
         returning the response object.
         """
-        return self.client.post(self.url, self._post_body(user, client, token_type))  # pylint: disable=no-member
+        return self.client.post(
+            self.url,
+            self._post_body(user, client, token_type, scopes)
+        )  # pylint: disable=no-member
 
-    def _post_body(self, user, client, token_type=None):
+    def _post_body(self, user, client, token_type=None, scopes=None):
         """
         Return a dictionary to be used as the body of the POST request
         """
@@ -122,7 +148,7 @@ class TestAccessTokenView(AccessTokenLoginMixin, mixins.AccessTokenMixin, _Dispa
         self.url = reverse('access_token')
         self.view_class = views.AccessTokenView
 
-    def _post_body(self, user, client, token_type=None):
+    def _post_body(self, user, client, token_type=None, scopes=None):
         """
         Return a dictionary to be used as the body of the POST request
         """
@@ -135,6 +161,9 @@ class TestAccessTokenView(AccessTokenLoginMixin, mixins.AccessTokenMixin, _Dispa
 
         if token_type:
             body['token_type'] = token_type
+
+        if scopes:
+            body['scope'] = scopes
 
         return body
 
@@ -216,6 +245,25 @@ class TestAccessTokenView(AccessTokenLoginMixin, mixins.AccessTokenMixin, _Dispa
         # and assert that it fails
         self._assert_access_token_invalidated(data['access_token'])
 
+    def test_allowed_scope_access_token(self):
+        """
+        Verify that an access_token generated for a RestrictedApplication fails when
+        submitted to an API endpoint
+        """
+
+        response = self._post_request(self.user, self.restricted_dot_app, scopes='profile')
+        self.assertEqual(response.status_code, 200)
+
+    def test_disallowed_scope_access_token(self):
+        """
+        Verify that an access_token generated for a RestrictedApplication fails when
+        submitted to an API endpoint
+        """
+
+        # now check no access to a scope not allowed on the application
+        response = self._post_request(self.user, self.restricted_dot_app_limited_scopes, scopes='email')
+        self.assertEqual(response.status_code, 401)
+
     def test_dot_access_token_provides_refresh_token(self):
         response = self._post_request(self.user, self.dot_app)
         self.assertEqual(response.status_code, 200)
@@ -240,7 +288,7 @@ class TestAccessTokenExchangeView(ThirdPartyOAuthTestMixinGoogle, ThirdPartyOAut
         self.view_class = views.AccessTokenExchangeView
         super(TestAccessTokenExchangeView, self).setUp()
 
-    def _post_body(self, user, client, token_type=None):
+    def _post_body(self, user, client, token_type=None, scopes=None):
         return {
             'client_id': client.client_id,
             'access_token': self.access_token,

--- a/openedx/core/djangoapps/profile_images/views.py
+++ b/openedx/core/djangoapps/profile_images/views.py
@@ -19,7 +19,7 @@ from openedx.core.lib.api.authentication import (
     SessionAuthenticationAllowInactiveUser,
 )
 from openedx.core.lib.api.parsers import TypedFileUploadParser
-from openedx.core.lib.api.permissions import IsUserInUrl
+from openedx.core.lib.api.permissions import IsUserInUrl, OAuth2RestrictedApplicatonPermission
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_names, set_has_profile_image
 from .exceptions import ImageValidationError
@@ -113,7 +113,11 @@ class ProfileImageView(DeveloperErrorViewMixin, APIView):
 
     parser_classes = (MultiPartParser, FormParser, TypedFileUploadParser)
     authentication_classes = (OAuth2AuthenticationAllowInactiveUser, SessionAuthenticationAllowInactiveUser)
-    permission_classes = (permissions.IsAuthenticated, IsUserInUrl)
+    permission_classes = (
+        permissions.IsAuthenticated,
+        IsUserInUrl,
+        OAuth2RestrictedApplicatonPermission,
+    )
 
     upload_media_types = set(itertools.chain(*(image_type.mimetypes for image_type in IMAGE_TYPES.values())))
 

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -15,6 +15,7 @@ from openedx.core.lib.api.authentication import (
     SessionAuthenticationAllowInactiveUser,
     OAuth2AuthenticationAllowInactiveUser,
 )
+from openedx.core.lib.api.permissions import OAuth2RestrictedApplicatonPermission
 from openedx.core.lib.api.parsers import MergePatchParser
 from .api import get_account_settings, update_account_settings
 from ..errors import UserNotFound, UserNotAuthorized, AccountUpdateError, AccountValidationError
@@ -144,7 +145,10 @@ class AccountViewSet(ViewSet):
     authentication_classes = (
         OAuth2AuthenticationAllowInactiveUser, SessionAuthenticationAllowInactiveUser, JwtAuthentication
     )
-    permission_classes = (permissions.IsAuthenticated,)
+    permission_classes = (
+        permissions.IsAuthenticated,
+        OAuth2RestrictedApplicatonPermission,
+    )
     parser_classes = (MergePatchParser,)
 
     def list(self, request):

--- a/openedx/core/djangoapps/user_api/preferences/views.py
+++ b/openedx/core/djangoapps/user_api/preferences/views.py
@@ -17,6 +17,7 @@ from openedx.core.lib.api.authentication import (
     SessionAuthenticationAllowInactiveUser,
     OAuth2AuthenticationAllowInactiveUser,
 )
+from openedx.core.lib.api.permissions import OAuth2RestrictedApplicatonPermission
 from openedx.core.lib.api.parsers import MergePatchParser
 from openedx.core.lib.api.permissions import IsUserInUrlOrStaff
 from ..errors import UserNotFound, UserNotAuthorized, PreferenceValidationError, PreferenceUpdateError
@@ -87,7 +88,11 @@ class PreferencesView(APIView):
             returned with no additional content.
     """
     authentication_classes = (OAuth2AuthenticationAllowInactiveUser, SessionAuthenticationAllowInactiveUser)
-    permission_classes = (permissions.IsAuthenticated, IsUserInUrlOrStaff)
+    permission_classes = (
+        permissions.IsAuthenticated,
+        IsUserInUrlOrStaff,
+        OAuth2RestrictedApplicatonPermission,
+    )
     parser_classes = (MergePatchParser,)
 
     def get(self, request, username):
@@ -196,7 +201,11 @@ class PreferencesDetailView(APIView):
             returned with no additional content.
     """
     authentication_classes = (OAuth2AuthenticationAllowInactiveUser, SessionAuthenticationAllowInactiveUser)
-    permission_classes = (permissions.IsAuthenticated, IsUserInUrlOrStaff)
+    permission_classes = (
+        permissions.IsAuthenticated,
+        IsUserInUrlOrStaff,
+        OAuth2RestrictedApplicatonPermission,
+    )
 
     def get(self, request, username, preference_key):
         """

--- a/openedx/core/lib/api/permissions.py
+++ b/openedx/core/lib/api/permissions.py
@@ -4,11 +4,77 @@ API library for Django REST Framework permissions-oriented workflows
 
 from django.conf import settings
 from django.http import Http404
+from oauth2_provider.ext.rest_framework.permissions import TokenHasScope
 from rest_framework import permissions
 
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
+from provider.oauth2.models import AccessToken as DOPAccessToken
 from student.roles import CourseStaffRole, CourseInstructorRole
+
+from openedx.core.djangoapps.oauth_dispatch.models import RestrictedApplication
+
+
+class OAuth2RestrictedApplicatonPermission(TokenHasScope):
+    """
+    This permission class will inspect a request which contains an
+    OAuth2 acess_token. The following business logic is applied:
+
+    1) Is the OAuth2 token passed in a legacy django-oauth-provider (DOP) token, if so
+       all applications connecting via DOP reflect trusted internal applications
+    2) Is the access_token associated with a RestrictedApplication? If not,
+       the caller is viewed as a trusted application and the permission check is passed
+    3) If the access_token is associated with a RestrictedApplication, then:
+        2a) Get the 'scopes' from the access_token and inspect the passed in 'view'
+        2b) Inspect the view object for a 'required_scopes' attribute on the view
+        2c) If there is no 'required_scopes', then FAIL THE REQUEST, since the
+            view has not declared how to allow RestrictedApplication to access it
+        2d) If there is a 'required_scopes' attribute on the view object then make
+            sure that the access_token has that scope on it
+        2e) If access_token does not contain the 'required_scopes' then fail the request
+        2f) If all above checks succees, pass the permissions check
+    """
+
+    def has_permission(self, request, view):
+        """
+        Implement the business logic discussed above
+        """
+
+        token = request.auth
+
+        if not token:
+            # If we are not an OAuth2 request - some APIs in Open edX allow for Django Session
+            # based authentication, then we must pass here and continue with other
+            # possible authorization checks declared on the API endpoint
+            return True
+
+        # check to see if token is a DOP token
+        # if so this represents a client which is implicitly trusted
+        # (since it is an internal Open edX application)
+        if isinstance(token, DOPAccessToken):
+            return True
+
+        if not RestrictedApplication.is_token_a_restricted_application(token.token):
+            # Application is not a restricted application, therefore it is trusted and can pass
+            # this specific check, although the API endpoint might declare other permission
+            # checks
+            return True
+
+        # caller is now confirmed to be a RestrictedApplication
+        # now we must assert that the view that is being called into
+        # has exposed the 'required_scopes' attribute (to support the DOT-based TokenHasScope check)
+        if not hasattr(view, 'required_scopes'):
+            # view has not declared a required_scopes attribute
+            # therefore it is interpreted as not properly supporting scoping and
+            # data filtering (aka RestrictedApplication's associated_orgs)
+            # thus we must fail the request as that endpoint is not secure
+            # yet for RestriectedApplications to call
+            return False
+
+        # now call into DOT permissions check which will inspect the view for a
+        # 'required_scopes' attribute and continue with the any additional
+        # permissions listed on the API endpoint
+        return super(OAuth2RestrictedApplicatonPermission, self).has_permission(request, view)
 
 
 class ApiKeyHeaderPermission(permissions.BasePermission):

--- a/openedx/core/lib/api/permissions.py
+++ b/openedx/core/lib/api/permissions.py
@@ -84,7 +84,7 @@ class OAuth2RestrictedApplicatonPermission(TokenHasScope):
             # NOTE: To avoid semantic ambiguity on None values, here we convert a
             # RestrictedApplication's org_association to an empty set if
             # it is None
-            request.auth.org_filter = (
+            request.auth.org_associations = (
                 restrictied_application.org_associations if
                 restrictied_application.org_associations else []
             )

--- a/openedx/core/lib/api/permissions.py
+++ b/openedx/core/lib/api/permissions.py
@@ -69,7 +69,7 @@ class OAuth2RestrictedApplicatonPermission(TokenHasScope):
             # therefore it is interpreted as not properly supporting scoping and
             # data filtering (aka RestrictedApplication's associated_orgs)
             # thus we must fail the request as that endpoint is not secure
-            # yet for RestriectedApplications to call
+            # yet for RestrictedApplications to call
             return False
 
         # now call into DOT permissions check which will inspect the view for a

--- a/openedx/core/lib/api/view_utils.py
+++ b/openedx/core/lib/api/view_utils.py
@@ -17,7 +17,7 @@ from openedx.core.lib.api.authentication import (
     SessionAuthenticationAllowInactiveUser,
     OAuth2AuthenticationAllowInactiveUser,
 )
-from openedx.core.lib.api.permissions import IsUserInUrl
+from openedx.core.lib.api.permissions import IsUserInUrl, OAuth2RestrictedApplicatonPermission
 
 
 class DeveloperErrorViewMixin(object):
@@ -101,6 +101,9 @@ def view_auth_classes(is_user=False, is_authenticated=True):
             func_or_class.permission_classes += (IsAuthenticated,)
         if is_user:
             func_or_class.permission_classes += (IsUserInUrl,)
+
+        # always check access by restricted OAuth2 applications
+        func_or_class.permission_classes += (OAuth2RestrictedApplicatonPermission, )
         return func_or_class
     return _decorator
 


### PR DESCRIPTION
This PR is an initial attempt at adapting the existing API endpoints to support the RestrictedApplication concepts recently merged upstream.

The primary changes are:
- a new OAuth2RestrictedApplicatonPermission Django-Rest-Framework permissions class that is to be added to every API endpoint that allows OAuth2 access (i.e. through the use of OAuth2AuthenticationAllowInactiveUser in the list of Authentication classes).
- Adding an "allowed_scopes" field to the RestrictedApplication datamodel (which was introduced in the upstream merge). This field will define - by an Open edX operator - which scopes a given RestrictedApplication can request. This is enforced via an override method on the existing DOT method (validate_scopes).
- Add an "associated_orgs" field to the RestrictedApplication datamodel (which was introduced in the upstream merge). This field will define - by an Open edX operator - which ORGs (in terms of ORG/COURSE/RUN tuples) the calling RestrictedApplication should be granted access.

In terms of the permissions logic behind OAuth2RestrictedApplicatonPermission, here is the flow on permission checks:
- If the request is not OAuth based (e.g. using SessionAuthentication), then pass the check - but the request will still have to pass the other existing DRF permission class checks
- If the request is OAuth, but is from a DOP (legacy) application (aka OAuth client), then the request is implicitly trusted since only Open edX software (e.g. mobile clients) are using DOP access tokens. In this case pass the check - but the request will still have to pass the other existing DRF permission class checks.
- If this request OAuth and is a DOT application (aka OAuth client), then see if this application is a RestrictedApplication. If it is NOT A RESTRICTED APPLICATION, in this case pass the check - but the request will still have to pass the other existing DRF permission class checks.
- At this stage, the request has been identified as a RestrictedApplication
- Look up the scopes on the passed in access_token, this reflects which scopes this access_token has been granted at the authorization/access_token generation stage.
- On the passed in 'view' parameter (as part of the DRF Permissions interface definition), look for a 'required_scopes' attribute on the view. If 'required_scopes' attribute does not exist on the view, then fail the check, as the API view is interpreted as not being RestrictedApplication safe.
- If the 'required_scopes' attribute is on the view, make sure that the access_token indeed has all of the required scopes, If not, FAIL THE PERMISSIONS CHECK. This code is actually in a base DRF TokenHasScope() built in permissions check.

DATA FILTERING:

As mentioned above, all RestrictedApplications must be defined - by an Open edX operator - which ORGs it is associated with (for example, 'MicrosoftX', etc.).

In the OAuth2RestrictedApplicatonPermission authorization check, if a request that is executing in the context of a RestrictedApplication and all permission checks pass, then an 'associated_orgs' attribute will be appended to the request.auth object so that it is available downstream during the API execution.

In the API handlers (for example 'list all enrollments for user), each API can get the request.auth.associated_orgs list to apply appropriate dataset filtering and/or permission checks (e.g. 'get grade on a course which is outside of allowed ORGs')

---

This design is backwards compatible with existing OAUTH2 clients and no changes to existing clients will need to happen.

This PR implements all of the framework and pipeline processing, the following API endpoints have been adapted to utilize this capability, reflecting APIs that the MPP initiative will need:
- my_user_info(), requiring a scope of the existing 'profile'
- Grades API: get user's grade for a course, requiring a new scope of "grades:read". RestrictedApplication can only request a grade for a course in the associated ORGs
- Enrollments API: get user's enrollments, requiring a new scope of "enrollments:read", filtering out all courses that are not associated with the ORGs
- Certificates API: get user's certificate for a course, requiring a new scope of "certificates:read". RestrictedApplication can only request a certificate info for a course in the associated ORGs

STATE OF THIS PR: All of the AuthN/AuthZ changes are complete. The above APIs have been modified (in a backwards compatible manner). Unit tests additions for the changed APIs are in place.

REMAINING WORK: Add unit tests for API endpoints to assert that RestirctedApplication truly don't have the rights to call the APIs that have not been changed to support RestrictedApplications (aka are not the above 4 API endpoints listed above).

As we map out the MPP integration, we may wish to add more APIs to the list of supported endpoints callable by RestrictedApplications. They would utilize the same patterns illustrated here.
