### PR TITLE
Fixed the bad word 'ass' which was found with policheck tool

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/problem/edit_spec_hint.coffee
+++ b/common/lib/xmodule/xmodule/js/spec/problem/edit_spec_hint.coffee
@@ -17,10 +17,10 @@ describe 'Markdown to xml extended hint dropdown', ->
       
       [[
         dogs		{{ NOPE::Not dogs, not cats, not toads }}
-        (FACES)	{{ With lots of makeup, doncha know?}}
+        (FACES)	{{ With lots of makeup, don't you know?}}
             
         money       {{ Clowns don't have any money, of course }}
-        donkeys     {{don't be an ass.}}
+        donkeys     {{ Clowns make tricks with donkeys }}
         -no hint-
       ]]
 


### PR DESCRIPTION
Fixed the bad word 'ass' which was found with policheck tool

No need to make any other change. Other Policheck errors are false-alarm:

- lez words are in French locale. So they look ok. There is no lez word in English contexts.
- I couldn't find the topless word in the edx-platform code base 
- I cannot see any wtf word in the platform. It is seen in some binary files and file names but that is ok.
- I cannot see any f* word in the platform
- cum words are not in English. They are in a different language and I looked from translator and they look ok sentences. 
@Microsoft/lex 