### PR TITLE
CMS TOS link and error pages changes

### DIFF
--- a/cms/templates/404.html
+++ b/cms/templates/404.html
@@ -11,12 +11,9 @@
       <h1 class="title title-1">${_("Page not found")}</h1>
     </header>
     <article class="content-primary" role="main">
-      <p>${_('The page that you were looking for was not found.')}
-       ${_('Go back to the {homepage} or let us know about any pages that may have been moved at {email}.').format(
-            homepage='<a href="/">homepage</a>',
-            email=u'<a href="mailto:{address}">{address}</a>'.format(
-                address=settings.TECH_SUPPORT_EMAIL,
-            ))}
+      <p>
+         ${_('The page that you were looking for was not found.')}
+	 ${_('Go back to the {homepage} or let us know about any pages that may have been moved by contacting support.')}
       </p>
     </article>
   </section>

--- a/cms/templates/500.html
+++ b/cms/templates/500.html
@@ -17,11 +17,7 @@
       <p>
         ${_("An error occurred in {studio_name} and the page could not be loaded. Please try again in a few moments.").format(studio_name=settings.STUDIO_SHORT_NAME)}
         ${_("We've logged the error and our staff is currently working to resolve this error as soon as possible.")}
-        ${_('If the problem persists, please email us at {email_link}.').format(
-              email_link=u'<a href="mailto:{email_address}">{email_address}</a>'.format(
-                  email_address=settings.TECH_SUPPORT_EMAIL,
-              )
-          )}
+        ${_('If the problem persists, please contact support.')}
       </p>
     </article>
   </section>

--- a/cms/templates/error.html
+++ b/cms/templates/error.html
@@ -13,27 +13,14 @@ from django.conf import settings
   % endif
 </%block>
 
-<%!
-help_link_start = '<a href="mailto:{email}">'.format(email=settings.TECH_SUPPORT_EMAIL)
-help_link_end = '</a>'
-%>
-
 <%block name="content">
   <article class="error-prompt">
     % if error == '404':
       <h1>${_("The Page You Requested Page Cannot be Found")}</h1>
-      <p class="description">${_("We're sorry. We couldn't find the {studio_name} page you're looking for. You may want to return to the {studio_name} Dashboard and try again. If you are still having problems accessing things, please feel free to {link_start}contact {studio_name} support{link_end} for further help.").format(
-          studio_name=settings.STUDIO_SHORT_NAME,
-          link_start=help_link_start,
-          link_end=help_link_end,
-        )}</p>
+      <p class="description">${_("We're sorry. We couldn't find the {studio_name} page you're looking for. You may want to return to the {studio_name} Dashboard and try again. If you are still having problems accessing things, please feel free to contact support')}</p>
     % elif error == '500':
       <h1>${_("The Server Encountered an Error")}</h1>
-      <p class="description">${_("We're sorry. There was a problem with the server while trying to process your last request. You may want to return to the {studio_name} Dashboard or try this request again. If you are still having problems accessing things, please feel free to {link_start}contact {studio_name} support{link_end} for further help.").format(
-          studio_name=settings.STUDIO_SHORT_NAME,
-          link_start=help_link_start,
-          link_end=help_link_end,
-        )}</p>
+      <p class="description">${_("We're sorry. There was a problem with the server while trying to process your last request. You may want to return to the {studio_name} Dashboard or try this request again. If you are still having problems accessing things, please feel free to contact {studio_name} support for further help.").format(studio_name=settings.STUDIO_SHORT_NAME )}</p>
     % endif
     <a href="/" class="back-button">${_("Back to dashboard")}</a>
   </article>

--- a/cms/templates/register.html
+++ b/cms/templates/register.html
@@ -66,9 +66,7 @@ from django.core.urlresolvers import reverse
 
             <li class="field checkbox required" id="field-tos">
               <input id="tos" name="terms_of_service" type="checkbox" value="true" />
-              <label for="tos">
-                ${_("I agree to the {a_start} Terms of Service {a_end}").format(a_start='<a data-rel="edx.org" href="{}">'.format(marketing_link('TOS')), a_end="</a>")}
-              </label>
+              I agree to the <a href="http://openedx.microsoft.com/tos">Terms of Service </a>
             </li>
           </ol>
         </fieldset>


### PR DESCRIPTION
1) I added the URL for Terms of Service on CMS register page.
2) On the CMS 404 and 500 error pages I removed the e-mail address and added "contact support text"
@Microsoft/lex 