### PR TITLE
Don't let enrolling course before activation, COPYRIGHT_YEAR fix and target="_blank" fix for links

### DIFF
--- a/cms/templates/register.html
+++ b/cms/templates/register.html
@@ -66,7 +66,7 @@ from django.core.urlresolvers import reverse
 
             <li class="field checkbox required" id="field-tos">
               <input id="tos" name="terms_of_service" type="checkbox" value="true" />
-              I agree to the <a href="http://openedx.microsoft.com/tos">Terms of Service </a>
+              I agree to the <a href="http://openedx.microsoft.com/tos" target="_blank">Terms of Service </a>
             </li>
           </ol>
         </fieldset>

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -960,6 +960,10 @@ def change_enrollment(request, check_access=True):
     if not user.is_authenticated():
         return HttpResponseForbidden()
 
+    #If account is not activated do not let the user to enroll in a course and show the error message
+    if not user.is_active:
+        return HttpResponseBadRequest(_("This account has not been activated yet. Please first activate your account by clicking the link in the sent activation e-mail."))
+
     # Ensure we received a course_id
     action = request.POST.get("enrollment_action")
     if 'course_id' not in request.POST:

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -32,6 +32,7 @@ Longer TODO:
 import sys
 import os
 import imp
+import datetime
 
 from path import Path as path
 from warnings import simplefilter
@@ -49,7 +50,7 @@ from lms.djangoapps.lms_xblock.mixin import LmsBlockMixin
 PLATFORM_NAME = "Your Platform Name Here"
 CC_MERCHANT_NAME = PLATFORM_NAME
 # Shows up in the platform footer, eg "(c) COPYRIGHT_YEAR"
-COPYRIGHT_YEAR = "2015"
+COPYRIGHT_YEAR = datetime.date.today().year
 
 PLATFORM_FACEBOOK_ACCOUNT = "http://www.facebook.com/YourPlatformFacebookAccount"
 PLATFORM_TWITTER_ACCOUNT = "@YourPlatformTwitterAccount"


### PR DESCRIPTION
1) If account is not activated do not let the user to enroll in a course and show the error message
"This account has not been activated yet. Please first activate your account by clicking the link in the sent activation e-mail."

2) In the lms/envs/common.py there was this line:
COPYRIGHT_YEAR = "2015"
This value is used in CMS pages like registration and footer. It was always showing 2015 for Copyright Year.

I fixed it with 
COPYRIGHT_YEAR = datetime.date.today().year 
so that it uses the current year. 

3) I put target="_blank" in the registration pages of CMS so that so that TOU opens in a new window/tab instead of taking over the current page. (I submitted another PR for fixing this in LMS with theming)

@Microsoft/lex 

