### PR TITLE
Commented out education levels highschool and below for account settings page

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -258,9 +258,9 @@ class UserProfile(models.Model):
         ('m', ugettext_noop("Master's or professional degree")),
         ('b', ugettext_noop("Bachelor's degree")),
         ('a', ugettext_noop("Associate degree")),
-        ('hs', ugettext_noop("Secondary/high school")),
-        ('jhs', ugettext_noop("Junior secondary/junior high/middle school")),
-        ('el', ugettext_noop("Elementary/primary school")),
+        #('hs', ugettext_noop("Secondary/high school")),
+        #('jhs', ugettext_noop("Junior secondary/junior high/middle school")),
+        #('el', ugettext_noop("Elementary/primary school")),
         # Translators: 'None' refers to the student's level of education
         ('none', ugettext_noop("No Formal Education")),
         # Translators: 'Other' refers to the student's level of education


### PR DESCRIPTION
Commented out education levels high school and below so that they are not displayed on account settings page.

We hid this on registration page. But account_settings page is not part of theming and we have to hide them here separately. 

@Microsoft/lex 
