### PR TITLE
Add code to check site_configuration value for ENFORCE_PASSWORD_POLICY

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1684,7 +1684,9 @@ def create_account_with_params(request, params):
 
     extended_profile_fields = configuration_helpers.get_value('extended_profile_fields', [])
     enforce_password_policy = (
-        settings.FEATURES.get("ENFORCE_PASSWORD_POLICY", False) and
+        configuration_helpers.get_value(
+            "ENFORCE_PASSWORD_POLICY", settings.FEATURES.get("ENFORCE_PASSWORD_POLICY", False)
+        ) and
         not do_external_auth
     )
     # Can't have terms of service for certain SHIB users, like at Stanford
@@ -2259,7 +2261,11 @@ def validate_password(user, password):
     """
     err_msg = None
 
-    if settings.FEATURES.get('ENFORCE_PASSWORD_POLICY', False):
+    enforce_password_policy = configuration_helpers.get_value(
+        "ENFORCE_PASSWORD_POLICY", settings.FEATURES.get("ENFORCE_PASSWORD_POLICY", False)
+    ) 
+
+    if enforce_password_policy:
         try:
             validate_password_strength(password)
         except ValidationError as err:


### PR DESCRIPTION
Add code to check site_configuration value for ENFORCE_PASSWORD_POLICY instead of just settings.FEATURES. This solves the error users registering with Azure Active Directory not being able to register because of Password Policy. Caveat: In non-base site, provide the configuration value "ENFORCE_PASSWORD_POLICY": false in the values field of the site configuration.

**Reason**
Azure AD Login was throwing a bad password error when creating the account. This change allows configuration values to be set in Site Configurations to turn off or on "ENFORCE_PASSWORD_POLICY" by site.