### PR TITLE
Fixes error 'TypeError: You cannot set the body to a text value without a charset'

### DIFF
--- a/common/lib/xmodule/xmodule/video_module/video_handlers.py
+++ b/common/lib/xmodule/xmodule/video_module/video_handlers.py
@@ -269,7 +269,8 @@ class VideoStudentViewHandlers(object):
                     headerlist=[
                         ('Content-Disposition', 'attachment; filename="{}"'.format(transcript_filename.encode('utf8'))),
                         ('Content-Language', self.transcript_language),
-                    ]
+                    ],
+                    charset='utf8'
                 )
                 response.content_type = transcript_mime_type
 


### PR DESCRIPTION
This PR includes a fix for this error 'TypeError: You cannot set the body to a text value without a charset' which was cherry-picked from https://github.com/edx/edx-platform/pull/14548.