### PR TITLE
Automatic sign-out should redirect to the sign-in page

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -73,6 +73,7 @@ urlpatterns += patterns(
     url(r'^howitworks$', 'howitworks'),
     url(r'^signup$', 'signup', name='signup'),
     url(r'^signin$', 'login_page', name='login'),
+    url(r'^login$', 'login_page', name='login1'),
     url(r'^request_course_creator$', 'request_course_creator', name='request_course_creator'),
 
     url(r'^course_team/{}(?:/(?P<email>.+))?$'.format(COURSELIKE_KEY_PATTERN), 'course_team_handler'),

--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -160,7 +160,7 @@ class LogoutTests(TestCase):
     def assert_logout_redirects(self):
         """ Verify logging out redirects the user to the homepage. """
         response = self.client.get(reverse('logout'))
-        self.assertRedirects(response, '/', fetch_redirect_response=False)
+        self.assertRedirects(response, '/login', fetch_redirect_response=False)
 
     def test_switch(self):
         """ Verify the IDA logout functionality is disabled if the associated switch is disabled. """
@@ -183,7 +183,7 @@ class LogoutTests(TestCase):
         response = self.assert_session_logged_out(client)
         expected = {
             'logout_uris': [client.logout_uri + '?no_redirect=1'],  # pylint: disable=no-member
-            'target': '/',
+            'target': '/login',
         }
         self.assertDictContainsSubset(expected, response.context_data)  # pylint: disable=no-member
 
@@ -195,7 +195,7 @@ class LogoutTests(TestCase):
         response = self.assert_session_logged_out(client, HTTP_REFERER=client.logout_uri)  # pylint: disable=no-member
         expected = {
             'logout_uris': [],
-            'target': '/',
+            'target': '/login',
         }
         self.assertDictContainsSubset(expected, response.context_data)  # pylint: disable=no-member
 

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -2607,7 +2607,7 @@ class LogoutView(TemplateView):
     template_name = 'logout.html'
 
     # Keep track of the page to which the user should ultimately be redirected.
-    target = reverse_lazy('cas-logout') if settings.FEATURES.get('AUTH_USE_CAS') else '/'
+    target = reverse_lazy('cas-logout') if settings.FEATURES.get('AUTH_USE_CAS') else '/login'
 
     def dispatch(self, request, *args, **kwargs):  # pylint: disable=missing-docstring
         # We do not log here, because we have a handler registered to perform logging on successful logouts.


### PR DESCRIPTION
#### What's this PR do? Any additional context?
     - when user clicks on signout it will redirect to signin page.

#### Where should the reviewer start?
     - signin into lms or cms and click signout .

#### How can this be manually tested? (brief repro steps)
     - Before : signout redirect to main home page.
       After : signout redirect to signin page.

#### What are the relevant TFS items? (list id numbers)
       Bug : 84811
 
#### Definition of done:
- [x ] Title of the pull request is clear and informative
- [ ] Add pull request hyperlink to relevant TFS items
- [ ] For large or complex change: schedule an in-person review session

[//]: # ( todo: Is there appropriate test coverage? )
[//]: # ( todo: Does this PR require a new Selenium test? )
[//]: # ( todo: Is there appropriate logging/monitoring included? )

#### Reminders BEFORE merging
1. Get at least two approvals
1. If you're merging into the development branch then "flatten" or "squash" commits
1. If merging from development into master then don't "flatten" or "squash" commits

#### Reminders AFTER merging
1. Delete the remote branch
1. Resolve relevant TFS items
1. (reverse merge) If you merged into master then check to see if there are any changes in master that can be merged down to the development branch (like hotfixes, etc)

[//]: # ( todo: If you merged into development branch then verify change in our "rolling deployment" environment. Then notify stakeholders interested in or involved with the change )


[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 3 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 4 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 5 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )
