### PR TITLE
Revert "Set 'created_on_site' UserAttribute on account creation"

### DIFF
--- a/common/djangoapps/student/tests/test_create_account.py
+++ b/common/djangoapps/student/tests/test_create_account.py
@@ -16,7 +16,6 @@ import pytz
 
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preference
 from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
-from openedx.core.djangoapps.site_configuration.tests.mixins import SiteMixin
 from notification_prefs import NOTIFICATION_PREF_KEY
 from openedx.core.djangoapps.external_auth.models import ExternalAuthMap
 import student
@@ -43,7 +42,7 @@ TEST_CS_URL = 'https://comments.service.test:123/'
         ]
     }
 )
-class TestCreateAccount(SiteMixin, TestCase):
+class TestCreateAccount(TestCase):
     """Tests for account creation"""
 
     def setUp(self):
@@ -75,12 +74,12 @@ class TestCreateAccount(SiteMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(get_user_preference(user, LANGUAGE_KEY), lang)
 
-    def create_account_and_fetch_profile(self, host='microsite.example.com'):
+    def create_account_and_fetch_profile(self):
         """
         Create an account with self.params, assert that the response indicates
         success, and return the UserProfile object for the newly created user
         """
-        response = self.client.post(self.url, self.params, HTTP_HOST=host)
+        response = self.client.post(self.url, self.params, HTTP_HOST="microsite.example.com")
         self.assertEqual(response.status_code, 200)
         user = User.objects.get(username=self.username)
         return user.profile
@@ -224,7 +223,6 @@ class TestCreateAccount(SiteMixin, TestCase):
         """
 
         request = self.request_factory.post(self.url, self.params)
-        request.site = self.site
         # now indicate we are doing ext_auth by setting 'ExternalAuthMap' in the session.
         request.session = import_module(settings.SESSION_ENGINE).SessionStore()  # empty session
         extauth = ExternalAuthMap(external_id='withmap@stanford.edu',
@@ -406,10 +404,6 @@ class TestCreateAccount(SiteMixin, TestCase):
                 UserAttribute.get_user_attribute(user, REGISTRATION_UTM_CREATED_AT)
             )
 
-
-    def test_created_on_site_user_attribute_set(self):
-        profile = self.create_account_and_fetch_profile(host=self.site.domain)
-        self.assertEqual(UserAttribute.get_user_attribute(profile.user, 'created_on_site'), self.site.domain)
 
 @ddt.ddt
 class TestCreateAccountValidation(TestCase):

--- a/common/djangoapps/student/tests/test_password_policy.py
+++ b/common/djangoapps/student/tests/test_password_policy.py
@@ -12,7 +12,6 @@ from django.test.utils import override_settings
 from django.conf import settings
 from mock import patch
 from openedx.core.djangoapps.external_auth.models import ExternalAuthMap
-from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from student.views import create_account
 
 
@@ -253,7 +252,6 @@ class TestPasswordPolicy(TestCase):
         """
         self.url_params['password'] = 'aaa'  # shouldn't pass validation
         request = self.request_factory.post(self.url, self.url_params)
-        request.site = SiteFactory.create()
         # now indicate we are doing ext_auth by setting 'ExternalAuthMap' in the session.
         request.session = import_module(settings.SESSION_ENGINE).SessionStore()  # empty session
         extauth = ExternalAuthMap(external_id='withmap@stanford.edu',

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1537,7 +1537,7 @@ def user_signup_handler(sender, **kwargs):  # pylint: disable=unused-argument
             log.info(u'user {} originated from a white labeled "Microsite"'.format(kwargs['instance'].id))
 
 
-def _do_create_account(form, custom_form=None, site=None):
+def _do_create_account(form, custom_form=None):
     """
     Given cleaned post variables, create the User and UserProfile objects, as well as the
     registration for this user.
@@ -1571,10 +1571,6 @@ def _do_create_account(form, custom_form=None, site=None):
                 custom_model = custom_form.save(commit=False)
                 custom_model.user = user
                 custom_model.save()
-
-            if site:
-                # Set UserAttribute indicating the site the user account was created on.
-                UserAttribute.set_user_attribute(user, 'created_on_site', site.domain)
     except IntegrityError:
         # Figure out the cause of the integrity error
         if len(User.objects.filter(username=user.username)) > 0:
@@ -1717,7 +1713,7 @@ def create_account_with_params(request, params):
     # Perform operations within a transaction that are critical to account creation
     with transaction.atomic():
         # first, create the account
-        (user, profile, registration) = _do_create_account(form, custom_form, site=request.site)
+        (user, profile, registration) = _do_create_account(form, custom_form)
 
         # next, link the account with social auth, if provided via the API.
         # (If the user is using the normal register page, the social auth pipeline does the linking, not this code)
@@ -2067,7 +2063,7 @@ def auto_auth(request):
     # If successful, this will return a tuple containing
     # the new user object.
     try:
-        user, profile, reg = _do_create_account(form, site=request.site)
+        user, profile, reg = _do_create_account(form)
     except (AccountValidationError, ValidationError):
         # Attempt to retrieve the existing user.
         user = User.objects.get(username=username)

--- a/common/djangoapps/third_party_auth/tests/specs/base.py
+++ b/common/djangoapps/third_party_auth/tests/specs/base.py
@@ -17,8 +17,8 @@ from django.conf import settings as django_settings
 from social import actions, exceptions
 from social.apps.django_app import utils as social_utils
 from social.apps.django_app import views as social_views
+
 from lms.djangoapps.commerce.tests import TEST_API_URL, TEST_API_SIGNING_KEY
-from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from student import models as student_models
 from student import views as student_views
 from student.tests.factories import UserFactory
@@ -514,7 +514,6 @@ class IntegrationTest(testutil.TestCase, test.TestCase):
         request = self.request_factory.get(
             pipeline.get_complete_url(self.backend_name) +
             '?redirect_state=redirect_state_value&code=code_value&state=state_value')
-        request.site = SiteFactory.create()
         request.user = auth_models.AnonymousUser()
         request.session = cache.SessionStore()
         request.session[self.backend_name + '_state'] = 'state_value'

--- a/openedx/core/djangoapps/external_auth/tests/test_ssl.py
+++ b/openedx/core/djangoapps/external_auth/tests/test_ssl.py
@@ -19,7 +19,6 @@ from mock import Mock, patch
 
 from openedx.core.djangoapps.external_auth.models import ExternalAuthMap
 import openedx.core.djangoapps.external_auth.views as external_auth_views
-from openedx.core.djangoapps.site_configuration.tests.factories import SiteFactory
 from student.models import CourseEnrollment
 from student.roles import CourseStaffRole
 from student.tests.factories import UserFactory
@@ -55,7 +54,6 @@ class SSLClientTest(ModuleStoreTestCase):
         """Creates a basic request for SSL use."""
         request = self.factory.get(url)
         request.META['SSL_CLIENT_S_DN'] = self.AUTH_DN.format(self.USER_NAME, self.USER_EMAIL)
-        request.site = SiteFactory.create()
         request.user = AnonymousUser()
         middleware = SessionMiddleware()
         middleware.process_request(request)


### PR DESCRIPTION
holding back multi-org courses in edx-platform (originally PR 40)