### PR TITLE
Updated urls and views for OXA Themed 404 page redirecting

### DIFF
--- a/lms/djangoapps/static_template_view/urls.py
+++ b/lms/djangoapps/static_template_view/urls.py
@@ -12,7 +12,7 @@ urlpatterns = (
     url(r'^t/(?P<template>[^/]*)$', 'index'),
 
     # Semi-static views (these need to be rendered and have the login bar, but don't change)
-    url(r'^404$', 'render', {'template': '404.html'}, name="404"),
+    url(r'^404$', 'render', {'template': 'static_templates/404.html'}, name="404"),
     # display error page templates, for testing purposes
     url(r'^404$', 'render_404'),  # Can this be deleted? Test test_404_microsites fails with this.
     url(r'^500$', 'render_500'),

--- a/lms/djangoapps/static_template_view/views.py
+++ b/lms/djangoapps/static_template_view/views.py
@@ -48,7 +48,7 @@ def render(request, template):
     try:
         return render_to_response('static_templates/' + template, {}, content_type=content_type)
     except TopLevelLookupException:
-        raise Http404
+        return HttpResponseNotFound(render_to_string('static_templates/404.html', {}, request=request))
 
 
 @ensure_csrf_cookie
@@ -71,7 +71,7 @@ def render_press_release(request, slug):
 
 
 def render_404(request):
-    return HttpResponseNotFound(render_to_string('static_templates/404.html', {}, request=request))
+    return redirect('/404')
 
 
 def render_500(request):


### PR DESCRIPTION
#### What does this PR do? Please provide some context
This will redirect any 404 page requests to the correct html file which is OXA themed and has correct message displayed.
#### Where should the reviewer start?
- lms/djangoapps/static_template_view/urls.py
- lms/djangoapps/static_template_view/views.py
When you navigate to any course URL which doesn't exist it will redirect to 404 page.
#### How can this be manually tested? (brief repro steps and corpnet-URL with change)
This can be tested by navigating to any course URL on lms and change the URL of that course which doesn't exist. For Example: https://openedx.microsoft.com/courses/course-v1:Microsoft+doesnotexist+2017_T4/about
#### What are the relevant TFS items? (list id numbers)
103517
#### Definition of done:
- [x] Title of the pull request is clear and informative
- [ ] For large or complex change: schedule an in-person review session
- [ ] This change has appropriate test coverage
- [x] Get at least two approvals

#### Reminders DURING merge
1. If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
1. If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.

[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 2 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 3 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 4 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )
