### PR TITLE
Video Uploads:  file name length validation

### DIFF
--- a/cms/djangoapps/azure_video_pipeline/utils.py
+++ b/cms/djangoapps/azure_video_pipeline/utils.py
@@ -224,7 +224,8 @@ def get_captions_info(video, path_locator_sas):
                 'download_url': '/{}?'.format(subtitle.content).join(path_locator_sas.split('?')),
                 'file_name': subtitle.content,
                 'language': subtitle.language,
-                'language_title': dict(all_languages_microsoft()).get(subtitle.language, subtitle.language)
+                'language_title': dict(all_languages_microsoft()).get(subtitle.language, subtitle.language),
+                'id': subtitle.id
             })
     return data
 

--- a/cms/djangoapps/contentstore/views/tests/test_videos.py
+++ b/cms/djangoapps/contentstore/views/tests/test_videos.py
@@ -778,7 +778,6 @@ class VideoTranscriptsTestCase(CourseTestCase):
             video=video_mock, language="test_language", content="test-file.name"
         )
         self.assertEqual(json_response.status_code, 200)
-        self.assertEqual(json.loads(json_response.content)["status"], "ok")
         self.assertEqual(
             json.loads(json_response.content)["transcript"], {"name": "test-file.name", "language": "test_language"}
         )

--- a/cms/djangoapps/contentstore/views/videos.py
+++ b/cms/djangoapps/contentstore/views/videos.py
@@ -85,6 +85,7 @@ def get_course_videos_data(course_key):
 STORAGE_SERVICE = get_storage_service()
 VIDEO_SUPPORTED_FILE_FORMATS = get_supported_video_formats()
 VIDEO_UPLOAD_MAX_FILE_SIZE_GB = 5
+VIDEO_MAX_LENGTH_FILE_NAME = 36
 
 # maximum time for video to remain in upload state
 MAX_UPLOAD_HOURS = 24
@@ -378,6 +379,7 @@ def videos_index_html(course):
             "concurrent_upload_limit": settings.VIDEO_UPLOAD_PIPELINE.get("CONCURRENT_UPLOAD_LIMIT", 0),
             "video_supported_file_formats": VIDEO_SUPPORTED_FILE_FORMATS.keys(),
             "video_upload_max_file_size": VIDEO_UPLOAD_MAX_FILE_SIZE_GB,
+            "video_max_length_file_name": VIDEO_MAX_LENGTH_FILE_NAME,
             "storage_service": STORAGE_SERVICE,
             "transcript_handler_url": reverse_course_url("video_transcripts_handler", unicode(course.id)),
             "languages": all_languages_microsoft()

--- a/cms/static/js/factories/videos_index.js
+++ b/cms/static/js/factories/videos_index.js
@@ -12,6 +12,7 @@ define([
         previousUploads,
         videoSupportedFileFormats,
         videoUploadMaxFileSizeInGB,
+        videoMaxLengthFileName,
         storageService,
         transcriptHandlerUrl
     ) {
@@ -21,6 +22,7 @@ define([
                 uploadButton: uploadButton,
                 videoSupportedFileFormats: videoSupportedFileFormats,
                 videoUploadMaxFileSizeInGB: videoUploadMaxFileSizeInGB,
+                videoMaxLengthFileName: videoMaxLengthFileName,
                 storageService: storageService,
                 onFileUploadDone: function(activeVideos) {
                     $.ajax({

--- a/cms/static/js/spec/views/active_video_upload_list_spec.js
+++ b/cms/static/js/spec/views/active_video_upload_list_spec.js
@@ -42,6 +42,7 @@ define(
                 this.uploadButton = $('<button>');
                 this.videoSupportedFileFormats = ['.mp4', '.mov'];
                 this.videoUploadMaxFileSizeInGB = 5;
+                this.videoMaxLengthFileName = 36;
                 this.storageService = 's3';
                 this.view = new ActiveVideoUploadListView({
                     concurrentUploadLimit: concurrentUploadLimit,
@@ -49,6 +50,7 @@ define(
                     uploadButton: this.uploadButton,
                     videoSupportedFileFormats: this.videoSupportedFileFormats,
                     videoUploadMaxFileSizeInGB: this.videoUploadMaxFileSizeInGB,
+                    videoMaxLengthFileName: this.videoMaxLengthFileName,
                     storageService: this.storageService
                 });
                 this.view.render();
@@ -388,6 +390,30 @@ define(
                             StringUtils.interpolate(
                                 '{fileName} is not in a supported file format. Supported file formats are {supportedFormats}.',  // eslint-disable-line max-len
                                 {fileName: files[index].name, supportedFormats: self.videoSupportedFileFormats.join(' and ')}  // eslint-disable-line max-len
+                            )
+                        );
+                    });
+                });
+            });
+
+            describe('filename length', function() {
+                it('should fail upload for not correct filename length', function() {
+                    var files = [
+                            {name: 'test-max_length_123456789012345678901.mp4', size: 0}
+                        ],
+                        unSupportedFiles = {
+                            files: files
+                        },
+                        self = this;
+                    this.view.storageService = 'azure';
+                    this.view.$uploadForm.fileupload('add', unSupportedFiles);
+                    _.each(this.view.itemViews, function(uploadView) {
+                        verifyUploadViewInfo(
+                            uploadView,
+                            'Your file could not be uploaded',
+                            StringUtils.interpolate(
+                                'The filename length can not exceed {maxLengthFileName} symbols.',
+                                {maxLengthFileName: self.videoMaxLengthFileName}
                             )
                         );
                     });

--- a/cms/static/js/views/active_video_upload_list.js
+++ b/cms/static/js/views/active_video_upload_list.js
@@ -43,6 +43,7 @@ define([
                 this.postUrl = options.postUrl;
                 this.videoSupportedFileFormats = options.videoSupportedFileFormats;
                 this.videoUploadMaxFileSizeInGB = options.videoUploadMaxFileSizeInGB;
+                this.videoMaxLengthFileName = options.videoMaxLengthFileName;
                 this.storageService = options.storageService;
                 this.onFileUploadDone = options.onFileUploadDone;
                 if (options.uploadButton) {
@@ -364,6 +365,11 @@ define([
                         )
                         .replace('{filename}', fileName)
                         .replace('{maxFileSizeInGB}', self.videoUploadMaxFileSizeInGB);
+                    } else if (self.storageService === 'azure' && fileName.length > self.videoMaxLengthFileName) {
+                        error = gettext(
+                            'The filename length can not exceed {maxLengthFileName} symbols.'
+                        )
+                        .replace('{maxLengthFileName}', self.videoMaxLengthFileName);
                     }
 
                     if (error) {

--- a/cms/static/js/views/previous_transcripts_video_upload.js
+++ b/cms/static/js/views/previous_transcripts_video_upload.js
@@ -24,8 +24,8 @@ define(
 
             render: function() {
                 var data = this.model.attributes;
-                data['clientVideoId'] = this.clientVideoId;
-                data['viewId'] = this.cid;
+                data.clientVideoId = this.clientVideoId;
+                data.viewId = this.cid;
                 HtmlUtils.setHtml(
                     this.$el,
                     this.template(data)

--- a/cms/static/js/views/settings/intro_video_azure.js
+++ b/cms/static/js/views/settings/intro_video_azure.js
@@ -54,13 +54,6 @@ define([
                 this.model.set('intro_video_manifest', responseData.video_info.smooth_streaming_url);
                 this.captions = responseData.captions;
                 this.render();
-            }).fail(function(response) {
-                var errorMsg;
-                try {
-                    errorMsg = JSON.parse(response.responseText).error;
-                } catch (error) {
-                    errorMsg = this.defaultFailureMessage;
-                }
             });
         },
 

--- a/cms/static/js/views/settings/main.js
+++ b/cms/static/js/views/settings/main.js
@@ -6,6 +6,7 @@ define(['js/views/validation', 'codemirror', 'underscore', 'jquery', 'jquery.ui'
        function(ValidatingView, CodeMirror, _, $, ui, DateUtils, FileUploadModel, FileUploadDialog,
                 LicenseView, LicenseModel, NotificationView, IntroVideoYouTubeView, IntroVideoAzureView,
                 timepicker, date, gettext, LearningInfoView, InstructorInfoView, StringUtils) {
+           'use strict';
            var DetailsView = ValidatingView.extend({
     // Model class is CMS.Models.Settings.CourseDetails
                events: {

--- a/cms/templates/js/settings-intro-video-azure.underscore
+++ b/cms/templates/js/settings-intro-video-azure.underscore
@@ -48,18 +48,18 @@
                 </div>
 
                 <% if (captions.length) { %>
-                <% _.forEach(captions, function(caption) { %>
+                <% _.forEach(captions, function(caption, index) { %>
                 <div class="show-data">
                     <div class="heading">
                         <input type="checkbox"
-                               id="captions-<%= caption.language%>"
+                               id="captions-<%= index%>"
                                class="intro-captions"
                                data-lang="<%= caption.language%>"
                                data-label="<%= caption.language_title%>"
                                data-url="<%= caption.download_url%>"
                             <%= captionEnabled(caption) ? 'checked' : '' %> />
-                        <label for="captions-<%= caption.language%>">
-                            <%= caption.language_title %>  (<%= caption.language %>)
+                        <label for="captions-<%= index%>">
+                            <%= caption.file_name %>  (<%= caption.language_title %>)
                         </label>
                     </div>
                 </div>

--- a/cms/templates/videos_index.html
+++ b/cms/templates/videos_index.html
@@ -36,6 +36,7 @@
             $contentWrapper.data("previous-uploads"),
             ${video_supported_file_formats | n, dump_js_escaped_json},
             ${video_upload_max_file_size | n, dump_js_escaped_json},
+            ${video_max_length_file_name | n, dump_js_escaped_json},
             ${storage_service | n, dump_js_escaped_json},
             ${transcript_handler_url | n, dump_js_escaped_json}
         );


### PR DESCRIPTION
@kabirkhan @sdolenc 
## Added
- uploaded files name length validation;

Note: accidentally, media player's restriction was discovered - source manifest URI can't be longer then certain string length. If so, such manifest is  considered as broken.