### PR TITLE
Removing old_email from user meta data

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -260,9 +260,6 @@ def update_account_settings(requesting_user, update, username=None, force_email_
                 subject = render_to_string('emails/email_change_subject.txt', address_context)
                 subject = ''.join(subject.splitlines())
                 message = render_to_string('emails/confirm_email_change.txt', address_context)
-                if 'old_emails' not in meta:
-                    meta['old_emails'] = []
-                meta['old_emails'].append([existing_user.email, datetime.datetime.now(UTC).isoformat()])
                 existing_user_profile.set_meta(meta)
                 existing_user_profile.save()
                 # Send it to the old email...


### PR DESCRIPTION
#### What does this PR do? Please provide some context
Removing the code that stores user's previous email as part of msa migration
#### Where should the reviewer start?
user's META will no longer store old_email of user
#### How can this be manually tested? (brief repro steps and corpnet-URL with change)
Migrate a user with MSA migration flow and check if old email is stored in user's meta data. 
#### What are the relevant TFS items? (list id numbers)
152303
#### Definition of done:
- [ ] Title of the pull request is clear and informative
- [ ] Add pull request hyperlink to relevant TFS items
- [ ] For large or complex change: schedule an in-person review session
- [ ] This change has appropriate test coverage
- [ ] Get at least two approvals

#### Reminders DURING merge
1. If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
1. If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.

[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 2 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 3 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 4 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )
