### PR TITLE
Disable the autocomplete attribute on the password input field

### DIFF
--- a/cms/templates/login.html
+++ b/cms/templates/login.html
@@ -36,7 +36,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
 
             <li class="field text required" id="field-password">
               <label for="password">${_("Password")}</label>
-              <input id="password" type="password" name="password" />
+              <input id="password" type="password" name="password" autocomplete="off" />
               <a href="${forgot_password_link}" class="action action-forgotpassword">${_("Forgot password?")}</a>
             </li>
           </ol>

--- a/cms/templates/register.html
+++ b/cms/templates/register.html
@@ -49,7 +49,7 @@ from django.core.urlresolvers import reverse
 
             <li class="field text required" id="field-password">
               <label for="password">${_("Password")}</label>
-              <input id="password" type="password" name="password" />
+              <input id="password" type="password" name="password" autocomplete="off" />
               <span id="password_error" class="tip tip-error hidden" role="alert"></span>
             </li>
 

--- a/themes/red-theme/cms/templates/login.html
+++ b/themes/red-theme/cms/templates/login.html
@@ -33,7 +33,7 @@ from django.utils.translation import ugettext as _
 
             <li class="field text required" id="field-password">
               <label for="password">${_("Password")}</label>
-              <input id="password" type="password" name="password" />
+              <input id="password" type="password" name="password" autocomplete="off" />
               <a href="${forgot_password_link}" class="action action-forgotpassword">${_("Forgot password?")}</a>
             </li>
           </ol>

--- a/themes/stanford-style/lms/templates/register-form.html
+++ b/themes/stanford-style/lms/templates/register-form.html
@@ -95,14 +95,14 @@ from student.models import UserProfile
 
     <li class="is-disabled field optional password" id="field-password" hidden>
       <label for="password">${_('Password')}</label>
-      <input id="password" type="password" name="password" value="" disabled required aria-required="true" />
+      <input id="password" type="password" name="password" value="" autocomplete="off" disabled required aria-required="true" />
     </li>
 
     % else:
 
     <li class="field required password" id="field-password">
       <label for="password">${_('Password')}</label>
-      <input id="password" type="password" name="password" value="" required aria-required="true" />
+      <input id="password" type="password" name="password" value="" autocomplete="off" required aria-required="true" />
     </li>
 
     % endif


### PR DESCRIPTION
What does this PR do? Please provide some context

Disables the autocomplete attribute on the input element where type="password"
Where should the reviewer start?

login.html, register.html, register-form.html
How can this be manually tested? (brief repro steps and corpnet-URL with change)

Enter password within form then later come back and enter password again. Autocomplete should not work.
What are the relevant TFS items? (list id numbers)

Bug 104035
Definition of done:

    Title of the pull request is clear and informative
    Add pull request hyperlink to relevant TFS items
    For large or complex change: schedule an in-person review session
    This change has appropriate test coverage
    Get at least two approvals

Reminders DURING merge

    If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
    If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.
