### PR TITLE
Added middleware that can be configured through Site Configuration to…

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1298,6 +1298,8 @@ MIDDLEWARE_CLASSES = [
 
     'waffle.middleware.WaffleMiddleware',
 
+    'openedx.core.djangoapps.site_configuration.middleware.LoginRequiredMiddleware',
+
     # This must be last
     'openedx.core.djangoapps.site_configuration.middleware.SessionCookieDomainOverrideMiddleware',
 ]

--- a/openedx/core/djangoapps/site_configuration/tests/test_middleware.py
+++ b/openedx/core/djangoapps/site_configuration/tests/test_middleware.py
@@ -3,6 +3,7 @@
 Test site_configuration middleware.
 """
 import ddt
+import unittest
 from mock import patch
 
 from django.conf import settings
@@ -21,7 +22,6 @@ from microsite_configuration.tests.tests import (
     MICROSITE_BACKENDS,
 )
 from openedx.core.djangoapps.site_configuration.tests.factories import SiteConfigurationFactory, SiteFactory
-from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 
 # NOTE: We set SESSION_SAVE_EVERY_REQUEST to True in order to make sure
@@ -29,7 +29,7 @@ from openedx.core.djangolib.testing.utils import skip_unless_lms
 # pylint: disable=no-member, protected-access
 @ddt.ddt
 @override_settings(SESSION_SAVE_EVERY_REQUEST=True)
-@skip_unless_lms
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
 class SessionCookieDomainMicrositeOverrideTests(DatabaseMicrositeTestCase):
     """
     Tests regarding the session cookie management in the middlware for Microsites
@@ -127,3 +127,53 @@ class SessionCookieDomainSiteConfigurationOverrideTests(TestCase):
         """
         response = self.client.get('/', HTTP_HOST=self.site.domain)
         self.assertIn(self.site.domain, str(response.cookies['sessionid']))
+
+class LoginRequiredMiddlewareTests(TestCase):
+
+    def setUp(self):
+        super(LoginRequiredMiddlewareTests, self).setUp()
+
+        self.user = UserFactory.create()
+        self.user.set_password('password')
+        self.user.save()
+        self.open_site = SiteFactory.create(
+            domain='testserver.fake.open',
+            name='testserver.fake.open'
+        )
+        self.open_site_configuration = SiteConfigurationFactory.create(
+            site=self.open_site,
+            values={}
+        )
+
+        self.restricted_site = SiteFactory.create(
+            domain='testserver.fake.restricted',
+            name='testserver.fake.restricted'
+        )
+        self.restricted_site_configuration = SiteConfigurationFactory.create(
+            site=self.restricted_site,
+            values={
+                "RESTRICT_SITE_TO_LOGGED_IN_USERS": True,
+                "LOGIN_EXEMPT_URLS": r'^about'
+            }
+        )
+        self.client = Client()
+
+    def test_anonymous_user_can_access_open_site(self):
+        response = self.client.get('/courses', HTTP_HOST=self.open_site.domain)
+        self.assertEqual(response.status_code, 200, 'Response: ' + str(response.status_code) + ' ' + str(response))
+
+    def test_anonymous_user_cannot_access_restricted_site(self):
+        response = self.client.get('/courses', HTTP_HOST=self.restricted_site.domain)
+        self.assertEqual(response.status_code, 302)
+
+    def test_logged_in_user_can_access_both_sites(self):
+        self.client.login(username=self.user.username, password="password")
+        o_response = self.client.get('/courses', HTTP_HOST=self.open_site.domain)
+        r_response = self.client.get('/courses', HTTP_HOST=self.restricted_site.domain)
+        self.assertEqual(o_response.status_code, 200)
+        self.assertEqual(r_response.status_code, 200)
+
+    def test_anonymous_user_can_access_login_exempt_urls_for_restricted_site(self):
+        response = self.client.get('/about', HTTP_HOST=self.restricted_site.domain)
+        self.assertEqual(response.status_code, 200)
+


### PR DESCRIPTION
What's this PR do? Any additional context?

Allows for individual sites to be restricted to only logged in users.
Allows certain urls to be enabled for all users using regex expressions
Formatting change to a previous change also seeped into this PR in common/djangoapps/student/forms.py
Where should the reviewer start?

openedx/core/djangoapps/site_configuration/middleware.py:LoginRequiredMiddleware
How can this be manually tested? (brief repro steps)

Enable sites
Pick a site and edit its site configuration values

{
"RESTRICT_SITE_TO_LOGGED_IN_USERS": true,
"LOGIN_EXEMPT_URLS": [
"^about"
]
}

    Without logging in, attempt to access the root url: '/'
    You should be redirected to login

    Without logging in, attempt to access the about url: '/about'
    You should be able to view this page.

What are the relevant TFS items? (list id numbers)

91390
Definition of done:

    Title of the pull request is clear and informative
    Add pull request hyperlink to relevant TFS items
    For large or complex change: schedule an in-person review session
    Is there appropriate test coverage?
    //: # ( todo: Does this PR require a new Selenium test? )
    //: # ( todo: Is there appropriate logging/monitoring included? )

Reminders BEFORE merging

    Get at least two approvals
    If you're merging into the development branch then "flatten" or "squash" commits
    If merging from development into master then don't "flatten" or "squash" commits

Reminders AFTER merging

    Delete the remote branch
    Resolve relevant TFS items
    (reverse merge) If you merged into master then check to see if there are any changes in master that can be merged down to the development branch (like hotfixes, etc)
