### PR TITLE
Adding an option to restrict the access in course catalog API

### DIFF
--- a/lms/djangoapps/course_api/tests/test_views.py
+++ b/lms/djangoapps/course_api/tests/test_views.py
@@ -14,8 +14,12 @@ from search.tests.utils import SearcherMixin
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, SharedModuleStoreTestCase
 
 from ..views import CourseDetailView
+from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 from .mixins import TEST_PASSWORD, CourseApiFactoryMixin
 
+TEST_SITE_CONFIGURATION = {
+    'RESTRICT_COURSES_API': True
+}
 
 class CourseApiTestViewMixin(CourseApiFactoryMixin):
     """
@@ -99,6 +103,16 @@ class CourseListViewTestCase(CourseApiTestViewMixin, SharedModuleStoreTestCase):
     def test_not_logged_in(self):
         self.client.logout()
         self.verify_response()
+
+    @with_site_configuration(configuration=TEST_SITE_CONFIGURATION)
+    def test_as_honor_with_site_configuration(self):
+        self.setup_user(self.honor_user)
+        self.verify_response(expected_status_code=403, params={'username': self.honor_user.username})
+
+    @with_site_configuration(configuration=TEST_SITE_CONFIGURATION)
+    def test_as_honor_with_site_configuration(self):
+        self.setup_user(self.staff_user)
+        self.verify_response(params=('username': self.staff_user.username})
 
 
 class CourseListViewTestCaseMultipleCourses(CourseApiTestViewMixin, ModuleStoreTestCase):


### PR DESCRIPTION
What does this PR do? Please provide some context

This will introduce new setting "RESTRICT_COURSES_API" in courses API which needs to be added in site configurations in admin panel to restrict the api for a specific site.
Where should the reviewer start?

deploy the code and add RESTRICT_COURSES_API to true in admin panel site_configurations and we can't access the site and throws error to users . url: "api/courses/v1/courses"
How can this be manually tested? (brief repro steps)

add this RESTRICT_COURSES_API in admin panel and we can see the api url is restricted. and can be accessed with access token with staff access
What are the relevant TFS items? (list id numbers)
Definition of done:

    Title of the pull request is clear and informative
    Add pull request hyperlink to relevant TFS items
    For large or complex change: schedule an in-person review session
    This change has appropriate test coverage

Reminders BEFORE merging

    Get at least two approvals
    If you're merging from a feature branch into the development branch then "flatten" or "squash" commits
    If merging from the development branch into master (or porting changes from upstream) then use github's UI to get review feedback, but use the git command line interface to complete the actual merge.

Reminders AFTER merging

    Delete the remote feature branch
    Resolve relevant TFS items
    (reverse merge) If you merged from the development branch into master then check to see if there are any changes in master that can be merged down to the development branch (like hotfixes, etc). In this case, use github's UI for feedback and the git command line interface for the actual merge.
