### PR TITLE
fixed course url in course email template

### DIFF
--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -124,6 +124,7 @@ def _get_course_email_context(course):
     }
     return email_context
 
+
 def perform_delegate_email_batches(entry_id, course_id, task_input, action_name):
     """
     Delegates emails by querying for the list of recipients who should

--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -102,22 +102,27 @@ def _get_course_email_context(course):
     course_end_date = get_default_time_display(course.end)
     course_root = reverse('course_root', kwargs={'course_id': course_id})
     course_url = '{}{}'.format(
-        settings.LMS_ROOT_URL,
+        configuration_helpers.get_value_for_org(course.org, 'LMS_ROOT_URL', settings.LMS_ROOT_URL),
         course_root
     )
-    image_url = u'{}{}'.format(settings.LMS_ROOT_URL, course_image_url(course))
+    image_url = u'{}{}'.format(
+        configuration_helpers.get_value_for_org(course.org, 'LMS_ROOT_URL', settings.LMS_ROOT_URL),
+        course_image_url(course))
     email_context = {
         'course_title': course_title,
         'course_root': course_root,
         'course_url': course_url,
         'course_image_url': image_url,
         'course_end_date': course_end_date,
-        'account_settings_url': '{}{}'.format(settings.LMS_ROOT_URL, reverse('account_settings')),
-        'email_settings_url': '{}{}'.format(settings.LMS_ROOT_URL, reverse('dashboard')),
+        'account_settings_url': '{}{}'.format(
+            configuration_helpers.get_value_for_org(course.org, 'LMS_ROOT_URL', settings.LMS_ROOT_URL),
+            reverse('account_settings')),
+        'email_settings_url': '{}{}'.format(
+            configuration_helpers.get_value_for_org(course.org, 'LMS_ROOT_URL', settings.LMS_ROOT_URL),
+            reverse('dashboard')),
         'platform_name': configuration_helpers.get_value('PLATFORM_NAME', settings.PLATFORM_NAME),
     }
     return email_context
-
 
 def perform_delegate_email_batches(entry_id, course_id, task_input, action_name):
     """


### PR DESCRIPTION
#### What does this PR do? Please provide some context
This will fetch the site configuration based on the Organization to which course belongs and add it to the course URL Prreviously it was fetching common LMS_ROOT_URL as a result even courses from different organization were getting same LMS_ROOT_URL. 

#### Where should the reviewer start?
Reviewer should check for the site configuration code

#### How can this be manually tested? (brief repro steps and corpnet-URL with change)
As an instructor user should go to insturctor tab and send a course invite email and check that in the course email template course link is pointing to correct LMS URL

#### What are the relevant TFS items? (list id numbers)
Bug_103970