### PR TITLE
added comprehensive themes to error pages in LMS and Studio

### DIFF
--- a/cms/djangoapps/contentstore/views/error.py
+++ b/cms/djangoapps/contentstore/views/error.py
@@ -5,6 +5,7 @@ from django.http import (HttpResponse, HttpResponseServerError,
 from edxmako.shortcuts import render_to_string, render_to_response
 import functools
 from openedx.core.djangolib.js_utils import dump_js_escaped_json
+from util.views import fix_crum_request
 
 __all__ = ['not_found', 'server_error', 'render_404', 'render_500']
 
@@ -37,11 +38,13 @@ def server_error(request):
     return render_to_response('error.html', {'error': '500'})
 
 
+@fix_crum_request
 @jsonable_error(404, "Resource not found")
 def render_404(request):
     return HttpResponseNotFound(render_to_string('404.html', {}, request=request))
 
 
+@fix_crum_request
 @jsonable_error(500, "The Studio servers encountered an error")
 def render_500(request):
     return HttpResponseServerError(render_to_string('500.html', {}, request=request))

--- a/lms/djangoapps/static_template_view/urls.py
+++ b/lms/djangoapps/static_template_view/urls.py
@@ -6,9 +6,6 @@ from django.conf import settings
 from django.conf.urls import patterns, url
 
 
-handler404 = 'lms.djangoapps.static_template_view.views.handler404'
-handler500 = 'lms.djangoapps.static_template_view.views.handler500'
-
 urlpatterns = (
     'static_template_view.views',
 

--- a/lms/djangoapps/static_template_view/views.py
+++ b/lms/djangoapps/static_template_view/views.py
@@ -13,6 +13,7 @@ from django.http import HttpResponseNotFound, HttpResponseServerError, Http404
 from django.views.decorators.csrf import ensure_csrf_cookie
 
 from util.cache import cache_if_anonymous
+from util.views import fix_crum_request
 
 valid_templates = []
 
@@ -70,23 +71,11 @@ def render_press_release(request, slug):
         return resp
 
 
+@fix_crum_request
 def render_404(request):
     return HttpResponseNotFound(render_to_string('static_templates/404.html', {}, request=request))
 
 
+@fix_crum_request
 def render_500(request):
     return HttpResponseServerError(render_to_string('static_templates/server-error.html', {}, request=request))
-
-
-def handler404(request):
-    response = render_to_response('static_templates/404.html', {},
-                                  context_instance=RequestContext(request))
-    response.status_code = 404
-    return response
-
-
-def handler500(request):
-    response = render_to_response('static_templates/server-error.html', {},
-                                  context_instance=RequestContext(request))
-    response.status_code = 500
-    return response


### PR DESCRIPTION
#### What does this PR do? Please provide some context
This PR will let comprehensive theme to work for error pages. Even if we add 404 and 500 error pages html in comprehensive theme, openedx is unable to load and render the default 404/500 page instead. This is a known bug and fixed in new release of edx

Didn't wanted to do a cherry-pick as there are lot of other changes which might affect our oxa/dev.fic branch
#### Where should the reviewer start?
Review should look at the already created ticket in Openedx
https://openedx.atlassian.net/browse/CRI-75

and PR related to solution in edx/platform
https://github.com/edx/edx-platform/commit/67442c26412c78471944a957d91e3bf8ac69390f

#### How can this be manually tested? (brief repro steps and corpnet-URL with change)
It can be tested by providing any invalid URL

#### What are the relevant TFS items? (list id numbers)

#### Definition of done:
- [ ] Title of the pull request is clear and informative
- [ ] Add pull request hyperlink to relevant TFS items
- [ ] For large or complex change: schedule an in-person review session
- [ ] This change has appropriate test coverage
- [ ] Get at least two approvals

#### Reminders DURING merge
1. If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
1. If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.

[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 2 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 3 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 4 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )
