### PR TITLE
Automatic sign-out should redirect to the sign-in page

### DIFF
--- a/cms/urls.py
+++ b/cms/urls.py
@@ -77,6 +77,7 @@ urlpatterns = [
     url(r'^howitworks$', contentstore.views.howitworks, name='howitworks'),
     url(r'^signup$', contentstore.views.signup, name='signup'),
     url(r'^signin$', contentstore.views.login_page, name='login'),
+    url(r'^login$', contentstore.views.login_page, name='login1'),
     url(r'^request_course_creator$', contentstore.views.request_course_creator, name='request_course_creator'),
     url(r'^course_team/{}(?:/(?P<email>.+))?$'.format(COURSELIKE_KEY_PATTERN),
         contentstore.views.course_team_handler, name='course_team_handler'),

--- a/common/djangoapps/student/tests/test_views.py
+++ b/common/djangoapps/student/tests/test_views.py
@@ -202,7 +202,7 @@ class LogoutTests(TestCase):
     def assert_logout_redirects_to_root(self):
         """ Verify logging out redirects the user to the homepage. """
         response = self.client.get(reverse('logout'))
-        self.assertRedirects(response, '/', fetch_redirect_response=False)
+        self.assertRedirects(response, '/login', fetch_redirect_response=False)
 
     def assert_logout_redirects_with_target(self):
         """ Verify logging out with a redirect_url query param redirects the user to the target. """
@@ -225,7 +225,7 @@ class LogoutTests(TestCase):
         response = self.assert_session_logged_out(client)
         expected = {
             'logout_uris': [client.logout_uri + '?no_redirect=1'],  # pylint: disable=no-member
-            'target': '/',
+            'target': '/login',
         }
         self.assertDictContainsSubset(expected, response.context_data)  # pylint: disable=no-member
 
@@ -237,7 +237,7 @@ class LogoutTests(TestCase):
         response = self.assert_session_logged_out(client, HTTP_REFERER=client.logout_uri)  # pylint: disable=no-member
         expected = {
             'logout_uris': [],
-            'target': '/',
+            'target': '/login',
         }
         self.assertDictContainsSubset(expected, response.context_data)  # pylint: disable=no-member
 

--- a/common/djangoapps/student/views/login.py
+++ b/common/djangoapps/student/views/login.py
@@ -736,7 +736,7 @@ class LogoutView(TemplateView):
     template_name = 'logout.html'
 
     # Keep track of the page to which the user should ultimately be redirected.
-    default_target = reverse_lazy('cas-logout') if settings.FEATURES.get('AUTH_USE_CAS') else '/'
+    default_target = reverse_lazy('cas-logout') if settings.FEATURES.get('AUTH_USE_CAS') else '/login'
 
     @property
     def target(self):


### PR DESCRIPTION
#### What's this PR do? Any additional context?
     - when user clicks on signout it will redirect to signin page.

#### Where should the reviewer start?
     - signin into lms or cms and click signout .

#### How can this be manually tested? (brief repro steps)
     - Before : signout redirect to main home page.
       After : signout redirect to signin page.

#### What are the relevant TFS items? (list id numbers)
       Bug : 84811
 
#### Definition of done:
- [x ] Title of the pull request is clear and informative
- [ ] Add pull request hyperlink to relevant TFS items
- [ ] For large or complex change: schedule an in-person review session

[//]: # ( todo: Is there appropriate test coverage? )
[//]: # ( todo: Does this PR require a new Selenium test? )
[//]: # ( todo: Is there appropriate logging/monitoring included? )

#### Reminders BEFORE merging
1. Get at least two approvals
1. If you're merging into the development branch then "flatten" or "squash" commits
1. If merging from development into master then don't "flatten" or "squash" commits

#### Reminders AFTER merging
1. Delete the remote branch
1. Resolve relevant TFS items
1. (reverse merge) If you merged into master then check to see if there are any changes in master that can be merged down to the development branch (like hotfixes, etc)

[//]: # ( todo: If you merged into development branch then verify change in our "rolling deployment" environment. Then notify stakeholders interested in or involved with the change )


[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 3 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 4 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 5 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )
