### PR TITLE
Hawthorn: Set HttpOnly to true for student cookies 

### DIFF
--- a/common/djangoapps/student/cookies.py
+++ b/common/djangoapps/student/cookies.py
@@ -35,7 +35,7 @@ def standard_cookie_settings(request):
         'expires': expires,
         'domain': settings.SESSION_COOKIE_DOMAIN,
         'path': '/',
-        'httponly': None,
+        'httponly': True,
     }
 
     return cookie_settings


### PR DESCRIPTION
#### What does this PR do? Please provide some context
Sets httponly to true for student cookies (edxloggedin, edx-user-info, etc). This ensures that a browser does not allow a client-side script to access the session cookie.

#### Where should the reviewer start?
common/djangoapps/student/cookies.py

#### How can this be manually tested? (brief repro steps and corpnet-URL with change)
Login and check the cookies to verify httponly is true for user based cookies

#### What are the relevant TFS items? (list id numbers)
Bug 104048
Task 65320

#### Definition of done:
- [ ] Title of the pull request is clear and informative
- [ ] Add pull request hyperlink to relevant TFS items
- [ ] For large or complex change: schedule an in-person review session
- [ ] This change has appropriate test coverage
- [ ] Get at least two approvals

#### Reminders DURING merge
1. If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
1. If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.

[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 2 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 3 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 4 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )
