### PR TITLE
Fix edX Developer Stack link in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ install edX:
    existing Ubuntu 12.04 server.
 
 .. _configuration repo: https://github.com/edx/configuration
-.. _edX Developer Stack: https://openedx.atlassian.net/wiki/display/OpenOPS/Running+Devstack
+.. _edX Developer Stack: https://openedx.atlassian.net/wiki/spaces/OpenOPS/pages/60227787/Running+Vagrant-based+Devstack
 .. _edX Full Stack: https://openedx.atlassian.net/wiki/display/OpenOPS/Running+Fullstack
 .. _edX Ubuntu 12.04 64-bit Installation: https://openedx.atlassian.net/wiki/display/OpenOPS/Native+Open+edX+Ubuntu+12.04+64+bit+Installation
 


### PR DESCRIPTION
This PR fixes the edX Developer Stack link in README.rst . The link was: https://openedx.atlassian.net/wiki/display/OpenOPS/Running+Devstack , but that leads to a redirect. Changing the link to: https://openedx.atlassian.net/wiki/spaces/OpenOPS/pages/60227787/Running+Vagrant-based+Devstack . fixes this issue and points straight to the deisred page.