### PR TITLE
[INTERIM] Reverting edX Hack since using Mongo-3.4 (CosmosDB)

### DIFF
--- a/common/lib/xmodule/xmodule/contentstore/mongo.py
+++ b/common/lib/xmodule/xmodule/contentstore/mongo.py
@@ -247,65 +247,20 @@ class MongoContentStore(ContentStore):
             contentType: The mimetype string of the asset
             md5: An md5 hash of the asset content
         '''
-        # TODO: Using an aggregate() instead of a find() here is a hack to get around the fact that Mongo 3.2 does not
-        # support sorting case-insensitively.
-        # If a sort on displayname is requested, the aggregation pipeline creates a new field:
-        # `insensitive_displayname`, a lowercase version of `displayname` that is sorted on instead.
-        # Mongo 3.4 does not require this hack. When upgraded, change this aggregation back to a find and specifiy
-        # a collation based on user's language locale instead.
-        # See: https://openedx.atlassian.net/browse/EDUCATOR-2221
-        pipeline_stages = []
         query = query_for_course(course_key, 'asset' if not get_thumbnails else 'thumbnail')
-        if filter_params:
-            query.update(filter_params)
-        pipeline_stages.append({'$match': query})
-
-        if sort:
-            sort = dict(sort)
-            if 'displayname' in sort:
-                pipeline_stages.append({
-                    '$project': {
-                        'contentType': 1,
-                        'locked': 1,
-                        'chunkSize': 1,
-                        'content_son': 1,
-                        'displayname': 1,
-                        'filename': 1,
-                        'length': 1,
-                        'import_path': 1,
-                        'uploadDate': 1,
-                        'thumbnail_location': 1,
-                        'md5': 1,
-                        'insensitive_displayname': {
-                            '$toLower': '$displayname'
-                        }
-                    }
-                })
-                sort = {'insensitive_displayname': sort['displayname']}
-            pipeline_stages.append({'$sort': sort})
-
-        # This is another hack to get the total query result count, but only the Nth page of actual documents
-        # See: https://stackoverflow.com/a/39784851/6620612
-        pipeline_stages.append({'$group': {'_id': None, 'count': {'$sum': 1}, 'results': {'$push': '$$ROOT'}}})
+        find_args = {"sort": sort}
         if maxresults > 0:
-            pipeline_stages.append({
-                '$project': {
-                    'count': 1,
-                    'results': {
-                        '$slice': ['$results', start, maxresults]
-                    }
-                }
+            find_args.update({
+                "skip":start,
+                "limit": maxresults,
             })
 
-        items = self.fs_files.aggregate(pipeline_stages)
-        if items['result']:
-            result = items['result'][0]
-            count = result['count']
-            assets = list(result['results'])
-        else:
-            # no results
-            count = 0
-            assets = []
+        if filter_params:
+            query.update(filter_params)
+
+        items = self.fs_files.find(query, **find_args)
+        count = items.count()
+        assets = list(items)
 
         # We're constructing the asset key immediately after retrieval from the database so that
         # callers are insulated from knowing how our identifiers are stored.


### PR DESCRIPTION
#### What does this PR do? Please provide some context
This change reverts a hack edX used to support case-insensitive sorting on Mongo 3.2. The aggregation pipeline technique doesn't work as expected on CosmosDB. Given the implicit intention revert the hack when edX migrates to Mongo 3.4 and the fact that CosmosDB is Mongo 3.4, this change reverts the hack. This change is marked INTERIM because I'd like to ensure that the existing functionality remains in place while still supporting clients with Mongo 3.4+ (most likely a branching statement)

See additional context in https://openedx.atlassian.net/browse/EDUCATOR-2221

#### Where should the reviewer start?

#### How can this be manually tested? (brief repro steps and corpnet-URL with change)

#### What are the relevant TFS items? (list id numbers)

#### Definition of done:
- [ ] Title of the pull request is clear and informative
- [ ] Add pull request hyperlink to relevant TFS items
- [ ] For large or complex change: schedule an in-person review session
- [ ] This change has appropriate test coverage
- [ ] Get at least two approvals

#### Reminders DURING merge
1. If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
1. If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.

[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 2 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 3 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 4 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )
