### PR TITLE
[Hawthorn] Disable password reset endpoint based on configuration value

### DIFF
--- a/lms/djangoapps/student_account/urls.py
+++ b/lms/djangoapps/student_account/urls.py
@@ -2,13 +2,14 @@ from django.conf import settings
 from django.conf.urls import url
 
 from student_account import views
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 urlpatterns = [
     url(r'^finish_auth$', views.finish_auth, name='finish_auth'),
     url(r'^settings$', views.account_settings, name='account_settings'),
 ]
 
-if settings.FEATURES.get('ENABLE_COMBINED_LOGIN_REGISTRATION'):
+if settings.FEATURES.get('ENABLE_COMBINED_LOGIN_REGISTRATION') and configuration_helpers.get_value('ENABLE_RESET_PASSWORD', True):
     urlpatterns += [
         url(r'^password$', views.password_change_request_handler, name='password_change_request'),
     ]


### PR DESCRIPTION
#### What does this PR do? Please provide some context
`This will disable password reset endpoint based on configuration from admin panel(site _configuration)
`
`Defaulted to true, To make it compatible with existing behavior` 
#### Where should the reviewer start?

#### How can this be manually tested? (brief repro steps and corpnet-URL with change)

#### What are the relevant TFS items? (list id numbers)

#### Definition of done:
- [ ] Title of the pull request is clear and informative
- [ ] Add pull request hyperlink to relevant TFS items
- [ ] For large or complex change: schedule an in-person review session
- [ ] This change has appropriate test coverage
- [ ] Get at least two approvals

#### Reminders DURING merge
1. If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
1. If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.

[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 2 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 3 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 4 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )
