### PR TITLE
Fix plumbing for REDIRECT_IS_HTTPS configuration

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -599,6 +599,12 @@ RETIREMENT_SERVICE_WORKER_USERNAME = ENV_TOKENS.get(
 )
 RETIREMENT_STATES = ENV_TOKENS.get('RETIREMENT_STATES', RETIREMENT_STATES)
 
+# Social Django defaults to HTTP scheme when generating redirect_uri
+# It is therefore necessary to add this setting in order to support
+# changing the redirect_uri to HTTPS. Defaulting to False (default behavior)
+# and expecting client to override.
+REDIRECT_IS_HTTPS = ENV_TOKENS.get('REDIRECT_IS_HTTPS', REDIRECT_IS_HTTPS)
+
 ####################### Plugin Settings ##########################
 
 from openedx.core.djangoapps.plugins import plugin_settings, constants as plugin_constants

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -1101,6 +1101,12 @@ RETIREMENT_STATES = ENV_TOKENS.get('RETIREMENT_STATES', RETIREMENT_STATES)
 ENABLE_COURSE_DISCOVERY = ENV_TOKENS.get('ENABLE_COURSE_DISCOVERY', ENABLE_COURSE_DISCOVERY)
 ENABLE_DASHBOARD_TABS = ENV_TOKENS.get('ENABLE_DASHBOARD_TABS', ENABLE_DASHBOARD_TABS)
 
+# Social Django defaults to HTTP scheme when generating redirect_uri
+# It is therefore necessary to add this setting in order to support
+# changing the redirect_uri to HTTPS. Defaulting to False (default behavior)
+# and expecting client to override.
+REDIRECT_IS_HTTPS = ENV_TOKENS.get('REDIRECT_IS_HTTPS', REDIRECT_IS_HTTPS)
+
 ############################### Plugin Settings ###############################
 
 from openedx.core.djangoapps.plugins import plugin_settings, constants as plugin_constants


### PR DESCRIPTION
#### What does this PR do? Please provide some context
Social Django defaults to HTTP scheme when generating redirect_uri during OAuth authentication. It is, therefore, necessary to add this setting to support changing the redirect_uri to HTTPS.

Defaulting to False (default behavior) and expecting the client to override. This change completes the plumbing of the new setting from [PR#461](https://github.com/Microsoft/edx-platform/pull/461)

#### Where should the reviewer start?

#### How can this be manually tested? (brief repro steps and corpnet-URL with change)

#### What are the relevant TFS items? (list id numbers)

#### Definition of done:
- [ ] Title of the pull request is clear and informative
- [ ] Add pull request hyperlink to relevant TFS items
- [ ] For large or complex change: schedule an in-person review session
- [ ] This change has appropriate test coverage
- [ ] Get at least two approvals

#### Reminders DURING merge
1. If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
1. If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.

[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 2 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 3 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 4 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )
