### PR TITLE
SALT Key randomization

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -75,7 +75,7 @@ from util.query import use_read_replica_if_available
 log = logging.getLogger(__name__)
 AUDIT_LOG = logging.getLogger("audit")
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore  # pylint: disable=invalid-name
-RETIRE_SALTS = [str(random.randrange(1, 10**10)), str(random.randrange(1, 10**10))]285
+RETIRE_SALTS = [str(random.randrange(1, 10**10)), str(random.randrange(1, 10**10))]
 
 # enroll status changed events - signaled to email_marketing.  See email_marketing.tasks for more info
 

--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -22,6 +22,7 @@ from importlib import import_module
 from urllib import urlencode
 
 import analytics
+import random
 from config_models.models import ConfigurationModel
 from django.apps import apps
 from django.conf import settings
@@ -74,6 +75,7 @@ from util.query import use_read_replica_if_available
 log = logging.getLogger(__name__)
 AUDIT_LOG = logging.getLogger("audit")
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore  # pylint: disable=invalid-name
+RETIRE_SALTS = [str(random.randrange(1, 10**10)), str(random.randrange(1, 10**10))]285
 
 # enroll status changed events - signaled to email_marketing.  See email_marketing.tasks for more info
 
@@ -266,7 +268,7 @@ def get_retired_username_by_username(username):
             return status.retired_username
     except UserRetirementStatus.DoesNotExist:
         pass
-    return user_util.get_retired_username(username, settings.RETIRED_USER_SALTS, settings.RETIRED_USERNAME_FMT)
+    return user_util.get_retired_username(username, RETIRE_SALTS, settings.RETIRED_USERNAME_FMT)
 
 
 def get_retired_email_by_email(email):
@@ -282,7 +284,7 @@ def get_retired_email_by_email(email):
             return status.retired_email
     except UserRetirementStatus.DoesNotExist:
         pass
-    return user_util.get_retired_email(email, settings.RETIRED_USER_SALTS, settings.RETIRED_EMAIL_FMT)
+    return user_util.get_retired_email(email, RETIRE_SALTS, settings.RETIRED_EMAIL_FMT)
 
 
 def get_all_retired_usernames_by_username(username):

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py
@@ -1034,6 +1034,82 @@ class TestAccountRetirementRetrieve(RetirementTestCase):
         self.assert_status_and_user_data(values, username_to_find=original_username)
 
 
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Account APIs are only supported in LMS')
+class TestAccountRetirementCleanup(RetirementTestCase):
+    """
+    Tests the account retirement cleanup endpoint.
+    """
+    def setUp(self):
+        super(TestAccountRetirementCleanup, self).setUp()
+        self.pending_state = RetirementState.objects.get(state_name='PENDING')
+        self.complete_state = RetirementState.objects.get(state_name='COMPLETE')
+        self.retirements = []
+        self.usernames = []
+
+        for _ in range(1, 10):
+            user = UserFactory()
+            self.retirements.append(create_retirement_status(user, state=self.complete_state))
+            self.usernames.append(user.username)
+
+        self.test_superuser = SuperuserFactory()
+        self.headers = build_jwt_headers(self.test_superuser)
+        self.headers['content_type'] = "application/json"
+        self.url = reverse('accounts_retirement_cleanup')
+
+    def cleanup_and_assert_status(self, data=None, expected_status=status.HTTP_204_NO_CONTENT):
+        """
+        Helper function for making a request to the retirement cleanup endpoint, and asserting the status.
+        """
+        if data is None:
+            data = {'usernames': self.usernames}
+
+        response = self.client.post(self.url, json.dumps(data), **self.headers)
+        print(response)
+        self.assertEqual(response.status_code, expected_status)
+        return response
+
+    def test_simple_success(self):
+        self.cleanup_and_assert_status()
+        self.assertFalse(UserRetirementStatus.objects.all())
+
+    def test_leaves_other_users(self):
+        remaining_usernames = []
+
+        # Create a bunch of local users in different states
+        for state in (self.pending_state, self.complete_state):
+            for _ in range(1, 3):
+                user = UserFactory()
+                remaining_usernames.append(create_retirement_status(user, state=state).user.username)
+
+        # Call should succeed and leave behind the local users in both states
+        self.cleanup_and_assert_status()
+        self.assertEqual(
+            UserRetirementStatus.objects.filter(user__username__in=remaining_usernames).count(),
+            len(remaining_usernames)
+        )
+
+    def test_no_usernames(self):
+        self.cleanup_and_assert_status(data={'usernames': []})
+
+    def test_bad_usernames(self):
+        self.cleanup_and_assert_status(data={'usernames': 'foo'}, expected_status=status.HTTP_400_BAD_REQUEST)
+
+    def test_nonexistent_username(self):
+        self.cleanup_and_assert_status(
+            data={'usernames': self.usernames + ['does not exist']},
+            expected_status=status.HTTP_400_BAD_REQUEST
+        )
+
+    def test_username_bad_state(self):
+        # Set one of the users we're looking up to a non-COMPLETE state to
+        # force the error
+        retirement = UserRetirementStatus.objects.get(user__username=self.usernames[0])
+        retirement.current_state = self.pending_state
+        retirement.save()
+
+        self.cleanup_and_assert_status(expected_status=status.HTTP_400_BAD_REQUEST)
+
+
 @ddt.ddt
 @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Account APIs are only supported in LMS')
 class TestAccountRetirementUpdate(RetirementTestCase):

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -958,6 +958,39 @@ class AccountRetirementStatusView(ViewSet):
         except Exception as exc:  # pylint: disable=broad-except
             return Response(text_type(exc), status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    def cleanup(self, request):
+        """
+        POST /api/user/v1/accounts/retirement_cleanup/
+
+        {
+            'usernames': ['user1', 'user2', ...]
+        }
+
+        Deletes a batch of retirement requests by username.
+        """
+        try:
+            usernames = request.data['usernames']
+
+            if not isinstance(usernames, list):
+                raise TypeError('Usernames should be an array.')
+
+            complete_state = RetirementState.objects.get(state_name='COMPLETE')
+            retirements = UserRetirementStatus.objects.filter(
+                original_username__in=usernames,
+                current_state=complete_state
+            )
+
+            # Sanity check that they're all valid usernames in the right state
+            if len(usernames) != len(retirements):
+                raise UserRetirementStatus.DoesNotExist('Not all usernames exist in the COMPLETE state.')
+
+            retirements.delete()
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        except (RetirementStateError, UserRetirementStatus.DoesNotExist, TypeError) as exc:
+            return Response(text_type(exc), status=status.HTTP_400_BAD_REQUEST)
+        except Exception as exc:  # pylint: disable=broad-except
+            return Response(text_type(exc), status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
 
 class LMSAccountRetirementView(ViewSet):
     """

--- a/openedx/core/djangoapps/user_api/urls.py
+++ b/openedx/core/djangoapps/user_api/urls.py
@@ -56,6 +56,10 @@ RETIREMENT_UPDATE = AccountRetirementStatusView.as_view({
     'patch': 'partial_update',
 })
 
+RETIREMENT_CLEANUP = AccountRetirementStatusView.as_view({
+    'post': 'cleanup',
+})
+
 RETIREMENT_POST = AccountRetirementView.as_view({
     'post': 'post',
 })


### PR DESCRIPTION
#### What does this PR do? Please provide some context
The SALT Keys for edx GDPR implementation is hardcoded which prevents the user from using the retired email to register back again. 

This PR will randomize the SALT keys to anonymize the username and email. therefore making the username and email irreversible and also enables the user to re-register with the retired email

#### Where should the reviewer start?
\lms\envs\common.py to understand the current implementation of the SALT keys
\common\djangoapps\student\models.py for the SALT key randomization

#### How can this be manually tested? (brief repro steps and corpnet-URL with change)
N/A


