### PR TITLE
Randomizing SALT Keys

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -13,6 +13,7 @@ file and check it in at the same time as your model changes. To do that,
 import hashlib
 import json
 import logging
+import random
 import six
 import uuid
 from collections import OrderedDict, defaultdict, namedtuple
@@ -74,6 +75,7 @@ from util.query import use_read_replica_if_available
 log = logging.getLogger(__name__)
 AUDIT_LOG = logging.getLogger("audit")
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore  # pylint: disable=invalid-name
+RETIRE_SALTS = [str(random.randrange(1, 10**10)), str(random.randrange(1, 10**10))]
 
 # enroll status changed events - signaled to email_marketing.  See email_marketing.tasks for more info
 
@@ -266,7 +268,7 @@ def get_retired_username_by_username(username):
             return status.retired_username
     except UserRetirementStatus.DoesNotExist:
         pass
-    return user_util.get_retired_username(username, settings.RETIRED_USER_SALTS, settings.RETIRED_USERNAME_FMT)
+    return user_util.get_retired_username(username, RETIRE_SALTS, settings.RETIRED_USERNAME_FMT)
 
 
 def get_retired_email_by_email(email):
@@ -282,7 +284,7 @@ def get_retired_email_by_email(email):
             return status.retired_email
     except UserRetirementStatus.DoesNotExist:
         pass
-    return user_util.get_retired_email(email, settings.RETIRED_USER_SALTS, settings.RETIRED_EMAIL_FMT)
+    return user_util.get_retired_email(email, RETIRE_SALTS, settings.RETIRED_EMAIL_FMT)
 
 
 def get_all_retired_usernames_by_username(username):


### PR DESCRIPTION
#### What does this PR do? Please provide some context
The SALT Keys for edx GDPR implementation is hardcoded which prevents the user from using the retired email to register back again.

This PR will randomize the SALT keys to anonymize the username and email. therefore making the username and email irreversible and also enables the user to re-register with the retired email

#### Where should the reviewer start?

\lms\envs\common.py to understand the current implementation of the SALT keys
\common\djangoapps\student\models.py for the SALT key randomization

#### How can this be manually tested? (brief repro steps and corpnet-URL with change)
N/A