### PR TITLE
Adding an option to restrict the access in course catalog API 

### DIFF
--- a/lms/djangoapps/course_api/tests/test_views.py
+++ b/lms/djangoapps/course_api/tests/test_views.py
@@ -18,6 +18,14 @@ from waffle.testutils import override_switch
 
 from ..views import CourseDetailView, CourseListUserThrottle
 from .mixins import TEST_PASSWORD, CourseApiFactoryMixin
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase, ModuleStoreTestCase
+from .mixins import CourseApiFactoryMixin, TEST_PASSWORD
+from ..views import CourseDetailView
+from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
+
+TEST_SITE_CONFIGURATION = {
+    'RESTRICT_COURSES_API': True
+}
 
 
 class CourseApiTestViewMixin(CourseApiFactoryMixin):
@@ -138,6 +146,17 @@ class CourseListViewTestCase(CourseApiTestViewMixin, SharedModuleStoreTestCase):
 
 
 @attr(shard=9)
+    @with_site_configuration(configuration=TEST_SITE_CONFIGURATION)
+    def test_as_honor_with_site_configuration(self):
+        self.setup_user(self.honor_user)
+        self.verify_response(expected_status_code=403, params={'username': self.honor_user.username})
+
+    @with_site_configuration(configuration=TEST_SITE_CONFIGURATION)
+    def test_as_honor_with_site_configuration(self):
+        self.setup_user(self.staff_user)
+        self.verify_response(params={'username': self.staff_user.username})
+
+
 class CourseListViewTestCaseMultipleCourses(CourseApiTestViewMixin, ModuleStoreTestCase):
     """
     Test responses returned from CourseListView (with tests that modify the

--- a/lms/djangoapps/course_api/tests/test_views.py
+++ b/lms/djangoapps/course_api/tests/test_views.py
@@ -18,10 +18,6 @@ from waffle.testutils import override_switch
 
 from ..views import CourseDetailView, CourseListUserThrottle
 from .mixins import TEST_PASSWORD, CourseApiFactoryMixin
-from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase, ModuleStoreTestCase
-from .mixins import CourseApiFactoryMixin, TEST_PASSWORD
-from ..views import CourseDetailView
-from openedx.core.djangoapps.site_configuration.tests.test_util import with_site_configuration
 
 TEST_SITE_CONFIGURATION = {
     'RESTRICT_COURSES_API': True

--- a/lms/djangoapps/course_api/views.py
+++ b/lms/djangoapps/course_api/views.py
@@ -4,7 +4,7 @@ Course API Views
 
 import search
 from django.conf import settings
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError, PermissionDenied
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.throttling import UserRateThrottle
 
@@ -15,6 +15,7 @@ from . import USE_RATE_LIMIT_2_FOR_COURSE_LIST_API, USE_RATE_LIMIT_10_FOR_COURSE
 from .api import course_detail, list_courses
 from .forms import CourseDetailGetForm, CourseListGetForm
 from .serializers import CourseDetailSerializer, CourseSerializer
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 
 
 @view_auth_classes(is_authenticated=False)
@@ -245,9 +246,12 @@ class CourseListView(DeveloperErrorViewMixin, ListAPIView):
         """
         Return a list of courses visible to the user.
         """
+        restrict_course_api = configuration_helpers.get_value('RESTRICT_COURSES_API')
         form = CourseListGetForm(self.request.query_params, initial={'requesting_user': self.request.user})
         if not form.is_valid():
             raise ValidationError(form.errors)
+        elif restrict_course_api and not self.request.user.is_staff:
+            raise PermissionDenied()
 
         db_courses = list_courses(
             self.request,


### PR DESCRIPTION
#### What does this PR do? Please provide some context
Adding an option to restrict the access in course catalog API. cherrypicked from (#129)
#### Where should the reviewer start?
deploy the code and add RESTRICT_COURSES_API to true in admin panel site_configurations and we can't access the site and throws error to users . url: "api/courses/v1/courses"

#### How can this be manually tested? (brief repro steps and corpnet-URL with change)
Add this RESTRICT_COURSES_API in admin panel and we can see the api url is restricted. and can be accessed with access token with staff access

#### What are the relevant TFS items? (list id numbers)

#### Definition of done:
- [ ] Title of the pull request is clear and informative
- [ ] Add pull request hyperlink to relevant TFS items
- [ ] For large or complex change: schedule an in-person review session
- [ ] This change has appropriate test coverage
- [ ] Get at least two approvals

#### Reminders DURING merge
1. If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
1. If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.

[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 2 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 3 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 4 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )
